### PR TITLE
Misc fixes and update to protk 1.4.2

### DIFF
--- a/make_protein_decoys/make_decoy.xml
+++ b/make_protein_decoys/make_decoy.xml
@@ -1,10 +1,10 @@
-<tool id="make_decoy" name="Generate protein decoy sequences" version="1.0.0">
+<tool id="make_decoy" name="Generate protein decoy sequences" version="1.0.1">
     <description>
         Generate random protein sequences with the same AA composition as input sequences
     </description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4.2">protk</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" level="fatal" description="Failure" />

--- a/make_protein_decoys/make_decoy.xml
+++ b/make_protein_decoys/make_decoy.xml
@@ -1,40 +1,35 @@
 <tool id="make_decoy" name="Generate protein decoy sequences" version="1.0.0">
-	<description>
-		Generate random protein sequences with the same AA composition as input sequences
-	</description>
-	<requirements>
-		<container type="docker">iracooke/protk-1.4.1</container>
-	    <requirement type="package" version="1.4">protk</requirement>
-   </requirements>
-
-	<command>
-		make_decoy.rb $fasta_file -o $output -P $prefix_string $append
-	</command>
-
-	<stdio>
-		<exit_code range="1:"   level="fatal"   description="Failure" />
-	</stdio>
-
-	<inputs>	
-		<param name="fasta_file" type="data" format="fasta" label="Fasta file contain protein sequences" />
-		<param name="prefix_string" help="Prefix String to use for Decoys" type="text" value="decoy_" label="Prefix String" size="20"/>		
-		<param name="append" type="boolean" label="Append input sequences to the generated sequences" help="" truevalue="--append" falsevalue="" />
-	</inputs>
-
-	<outputs>
-		<data format="fasta" name="output" />
-	</outputs>
-
-	<tests>
-	  <test>
-	      <param name="fasta_file" value="testdb.fasta" format="fasta"/>
-	      <output name="output" format="fasta">
-	      	<assert_contents>
-	      	    <has_text text="decoy_rp3" />
-	      	</assert_contents>
-	      </output>
-	  </test>
-	</tests>
+    <description>
+        Generate random protein sequences with the same AA composition as input sequences
+    </description>
+    <requirements>
+        <container type="docker">iracooke/protk-1.4.1</container>
+        <requirement type="package" version="1.4">protk</requirement>
+    </requirements>
+    <stdio>
+        <exit_code range="1:"   level="fatal"   description="Failure" />
+    </stdio>
+    <command>
+        make_decoy.rb $fasta_file -o $output -P $prefix_string $append
+    </command>
+    <inputs>
+        <param name="fasta_file" type="data" format="fasta" label="Fasta file contain protein sequences" />
+        <param name="prefix_string" help="Prefix String to use for Decoys" type="text" value="decoy_" label="Prefix String" size="20"/>        
+        <param name="append" type="boolean" label="Append input sequences to the generated sequences" help="" truevalue="--append" falsevalue="" />
+    </inputs>
+    <outputs>
+        <data format="fasta" name="output" />
+    </outputs>
+    <tests>
+      <test>
+          <param name="fasta_file" value="testdb.fasta" format="fasta"/>
+          <output name="output" format="fasta">
+              <assert_contents>
+                  <has_text text="decoy_rp3" />
+              </assert_contents>
+          </output>
+      </test>
+    </tests>
 
 
 

--- a/make_protein_decoys/make_decoy.xml
+++ b/make_protein_decoys/make_decoy.xml
@@ -1,12 +1,11 @@
 <tool id="make_decoy" name="Generate protein decoy sequences" version="1.0.0">
+	<description>
+		Generate random protein sequences with the same AA composition as input sequences
+	</description>
 	<requirements>
 		<container type="docker">iracooke/protk-1.4.1</container>
 	    <requirement type="package" version="1.4">protk</requirement>
    </requirements>
-
-	<description>
-		Generate random protein sequences with the same AA composition as input sequences
-	</description>
 
 	<command>
 		make_decoy.rb $fasta_file -o $output -P $prefix_string $append

--- a/make_protein_decoys/make_decoy.xml
+++ b/make_protein_decoys/make_decoy.xml
@@ -7,7 +7,7 @@
         <requirement type="package" version="1.4">protk</requirement>
     </requirements>
     <stdio>
-        <exit_code range="1:"   level="fatal"   description="Failure" />
+        <exit_code range="1:" level="fatal" description="Failure" />
     </stdio>
     <command>
         make_decoy.rb $fasta_file -o $output -P $prefix_string $append
@@ -30,16 +30,12 @@
           </output>
       </test>
     </tests>
-
-
-
-  <help>
+    <help>
 
 **What it does**
 
 Generates random protein sequences based on the amino acid composition of a given set of input sequences. To be used for decoy proteomics searches
 
 
-  </help>
-
+    </help>
 </tool>

--- a/make_protein_decoys/repository_dependencies.xml
+++ b/make_protein_decoys/repository_dependencies.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <repositories description="Proteomics datatypes">
     <repository name="proteomics_datatypes" owner="iracooke" />
- </repositories>
+</repositories>

--- a/make_protein_decoys/tool_dependencies.xml
+++ b/make_protein_decoys/tool_dependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="protk" version="1.4.2">
+        <repository name="package_protk_1_4_2" owner="iuc"/>
+    </package>
+</tool_dependency>

--- a/mascot/mascot.xml
+++ b/mascot/mascot.xml
@@ -1,249 +1,227 @@
 <tool id="proteomics_search_mascot_1" name="Mascot MSMS Search" version="1.1.0">
-	<description>Mascot MS/MS Search</description>
-	<requirements>
-            <container type="docker">iracooke/protk-1.4.1</container>
-	    <requirement type="package" version="1.4">protk</requirement>
-   </requirements>
+    <description>Mascot MS/MS Search</description>
+    <requirements>
+        <container type="docker">iracooke/protk-1.4.1</container>
+        <requirement type="package" version="1.4">protk</requirement>
+    </requirements>
+    <command>mascot_search.rb 
+
+        #if $database.source_select=="built_in":
+            -d $database.dbkey
+        #else 
+            -d $database.custom_db
+        #end if
+
+        -f $fragment_ion_tol 
+        -S $server $input_file 
+        -o $output
+        -r
+        ## Variable Mods
+
+        --var-mods='
+        $variable_mods
+        '
+        --fix-mods='
+        $fixed_mods
+        '
+
+        --allowed-charges='$allowed_charges'
+        --enzyme=$enzyme 
+        --instrument='$instrument'
+        -p $precursor_ion_tol
+        --precursor-ion-tol-units=$precursor_tolu 
+
+        #if $email
+            --email=$email 
+        #end if
+
+        -v $missed_cleavages
+        --quantitation='$quant_method'
+
+        #if $security.security_use
+            --use-security
+            --username $security.username
+            --password $security.password
+        #end if
+
+        #if $proxy
+            --proxy $proxy
+        #end if
+
+        --timeout=600
+
+    </command>
+    <inputs>
+        <param name="input_file" type="data" format="mgf" multiple="false" label="MSMS File" help="A Mascot Generic Format file containing MSMS Spectra"/>
+
+        <conditional name="database">
+            <param name="source_select" type="select" label="Database Type">
+                <option value="built_in">Built-In</option>
+                <option selected="true" value="custom_defined">Custom</option>
+            </param>
+            <when value="built_in">
+                <param name="dbkey" type="select" format="text" >
+                    <label>Database</label>
+                    <options from_file="mascot_databases.loc">
+                        <column name="name" index="0" />
+                        <column name="value" index="2" />
+                    </options>
+                </param>
+            </when>
+            <when value="custom_defined">
+                <param name="custom_db" type="text" size="80" value="SwissProt" label="Database Name" help="Exact name of a database defined on the Mascot server (case-sensitive)"/>
+            </when>
+        </conditional>
+
+        <param name="variable_mods" format="text" type="select" multiple="true" label="Variable Modifications" help="Multiple values allowed">
+            <options from_file="mascot_mods.loc">
+                <column name="name" index="0" />
+                <column name="value" index="2" />
+            </options>
+        </param>
+
+        <param name="fixed_mods" format="text" type="select" multiple="true" label="Fixed Modifications" help="Multiple values allowed">
+            <options from_file="mascot_mods.loc">
+                <column name="name" index="0" />
+                <column name="value" index="2" />
+            </options>
+        </param>
+
+        <param name="missed_cleavages" type="select" format="text">
+            <label>Missed Cleavages Allowed</label>
+            <option value="0">0</option>
+            <option value="1">1</option>
+            <option selected="true" value="2">2</option>
+        </param>
+
+        <param name="enzyme" type="select" format="text">
+            <label>Enzyme</label>
+            <option selected="true" value="Trypsin">Trypsin</option>
+            <option value="Trypsin/P">Trypsin/P</option>
+            <option value="Arg-C">Arg-C</option>
+            <option value="Asp-N">Asp-N</option>
+            <option value="Asp-N_ambic">Asp-N_ambic</option>
+            <option value="Chymotrypsin">Chymotrypsin</option>
+            <option value="CNBr">CNBr</option>
+            <option value="CNBr+Trypsin">CNBr+Trypsin</option>
+            <option value="Formic_acid">Formic_acid</option>
+            <option value="Lys-C">Lys-C</option>
+            <option value="Lys-C/P">Lys-C/P</option>
+               <option value="LysC+AspN">LysC+AspN</option>
+               <option value="Lys-N">Lys-N</option>
+               <option value="PepsinA">PepsinA</option>
+               <option value="semiTrypsin">semiTrypsin</option>
+               <option value="TrypChymo">TrypChymo</option>
+               <option value="TrypsinMSIPI">TrypsinMSIPI</option>
+               <option value="TrypsinMSIPI/P">TrypsinMSIPI/P</option>
+               <option value="V8-DE">V8-DE</option>
+               <option value="V8-E">V8-E</option>
+               <option value="none">none</option>
+        </param>
+
+        <param name="allowed_charges" type="select" format="text">
+            <label>Peptide Charge</label>
+            <option value="8-">8-</option>
+            <option value="7-">7-</option>
+            <option value="6-">6-</option>
+            <option value="5-">5-</option>
+            <option value="4-">4-</option>
+            <option value="3-">3-</option>
+            <option value="2-,3- and 4-">2-,3- and 4-</option>
+            <option value="2- and 3-">2- and 3-</option>
+            <option value="2-">2-</option>
+            <option value="1-,2- and 3-">1-,2- and 3-</option>
+            <option value="1-">1-</option>
+            <option value="Mr">Mr</option>
+            <option value="1+">1+</option>
+            <option value="1+, 2+ and 3+">1+,2+ and 3+</option>
+            <option value="2+">2+</option>
+            <option value="2+ and 3+">2+ and 3+</option>
+            <option selected="true" value="2+,3+ and 4+">2+,3+ and 4+</option>
+            <option value="3+">3+</option>
+            <option value="4+">4+</option>
+            <option value="5+">5+</option>
+            <option value="6+">6+</option>
+            <option value="7+">7+</option>
+            <option value="8+">8+</option>
+        </param>
+
+        <param name="instrument" type="select" format="text">
+            <label>Instrument</label>
+            <option value="ESI-QUAD-TOF">ESI-QUAD-TOF</option>
+            <option value="MALDI-TOF-PSD">MALDI-TOF-PSD</option>
+            <option selected="true" value="ESI-TRAP">ESI-TRAP</option>
+            <option value="ESI-QUAD">ESI-QUAD</option>
+            <option value="ESI-FTICR">ESI-FTICR</option>
+            <option value="MALDI-TOF-TOF">MALDI-TOF-TOF</option>
+            <option value="ESI-4SECTOR">ESI-4SECTOR</option>
+            <option value="FTMS-ECD">FTMS-ECD</option>
+            <option value="ETD-TRAP">ETD-TRAP</option>
+            <option value="MALDI-QUAD-TOF">MALDI-QUAD-TOF</option>
+            <option value="MALDI-QIT-TOF">MALDI-QIT-TOF</option>
+            <option value="MALDI-ISD">MALDI-ISD</option>
+            <option value="CID+ETD">CID+ETD</option>
+        </param>
 
 
+        <param name="quant_method" type="select" format="text">
+            <label>Quantitation</label>
+            <option selected="true" value="None">None</option>
+            <option value="iTRAQ 4plex">iTRAQ 4plex</option>
+            <option value="iTRAQ 4plex (protein)">iTRAQ 4plex (protein)</option>
+            <option value="iTRAQ 8plex">iTRAQ 8plex</option>
+            <option value="TMT 6plex">TMT 6plex</option>
+            <option value="TMT 2plex">TMT 2plex</option>
+            <option value="DiLeu 4plex">DiLeu 4plex</option>
+            <option value="18O multiplex">18O multiplex</option>
+            <option value="SILAC K+6 R+6 multiplex">SILAC K+6 R+6 multiplex</option>
+            <option value="IPTL (Succinyl and IMID) multiplex">IPTL (Succinyl and IMID) multiplex</option>
+            <option value="ICPL duplex pre-digest [MD]">ICPL duplex pre-digest [MD]</option>
+            <option value="ICPL duplex post-digest [MD]">ICPL duplex post-digest [MD]</option>
+            <option value="ICPL triplex pre-digest [MD]">ICPL triplex pre-digest [MD]</option>
+            <option value="ICPL quadruplex pre-digest [MD]">ICPL quadruplex pre-digest [MD]</option>
+            <option value="18O corrected [MD]">18O corrected [MD]</option>
+            <option value="15N Metabolic [MD]">15N Metabolic [MD]</option>
+            <option value="15N + 13C Metabolic [MD]">15N + 13C Metabolic [MD]</option>
+            <option value="SILAC K+6 R+10 [MD]">SILAC K+6 R+10 [MD]</option>
+            <option value="SILAC K+6 R+10 Arg-Pro [MD]">SILAC K+6 R+10 Arg-Pro [MD]</option>
+            <option value="SILAC K+6 R+6 [MD]">SILAC K+6 R+6 [MD]</option>
+            <option value="SILAC R+6 R+10 [MD]">SILAC R+6 R+10 [MD]</option>
+            <option value="SILAC K+8 R+10 [MD]">SILAC K+8 R+10 [MD]</option>        
+            <option value="SILAC K+4 K+8 R+6 R+10 [MD]">SILAC K+4 K+8 R+6 R+10 [MD]</option>
+            <option value="ICAT ABI Cleavable [MD]">ICAT ABI Cleavable [MD]</option>
+            <option value="ICAT D8 [MD]">ICAT D8 [MD]</option>
+            <option value="Dimethylation [MD]">Dimethylation [MD]</option>
+            <option value="NBS Shimadzu [MD]">NBS Shimadzu [MD]</option>
+            <option value="Acetylation [MD]">Acetylation [MD]</option>
+            <option value="Label-free [MD]">Label-free [MD]</option>
+        </param>
+        <param name="fragment_ion_tol" label="Fragment Ion Tolerance" type="float" value="0.5" min="0" max="10000" help="Fragment ion tolerance in Daltons"/>
 
+        <param name="precursor_ion_tol" label="Precursor Ion Tolerance (Da or ppm)" type="float" value="10" min="0" max="10000" help="Enter a value in Daltons or ppm depending on the units chosen below"/>
+        <param name="precursor_tolu" type="select" format="text">
+            <label>Precursor Ion Tolerance Units</label>
+            <option value="ppm">ppm</option>
+            <option value="Da">Da</option>
+        </param>
 
-	<command>mascot_search.rb 
+        <param name="server" type="text" label="URL to the cgi directory on the Mascot Server " size="60" value="http://www.exampleserver.com/mascot/cgi/"/>
+        <param name="proxy" type="text" label="Proxy Server URL including proxy port" size="60" value="" help="eg http://proxy.latrobe.edu.au:8080"/>
 
-		#if $database.source_select=="built_in":
-		-d $database.dbkey
-		#else 
-		-d $database.custom_db
-		#end if
-
-		-f $fragment_ion_tol 
-
-		-S $server $input_file 
-
-		-o $output 
-
-		-r
-		
-		## Variable Mods
-
-		--var-mods='
-		$variable_mods
-		'
-		
-		--fix-mods='
-		$fixed_mods
-		'
-
-		--allowed-charges='$allowed_charges'
-
-		--enzyme=$enzyme 
-
-		--instrument='$instrument'
-
-		-p $precursor_ion_tol
-		
-		--precursor-ion-tol-units=$precursor_tolu 
-
-		#if $email
-		--email=$email 
-		#end if
-
-		-v $missed_cleavages
-
-		--quantitation='$quant_method'
-
-		#if $security.security_use
-		--use-security
-		--username $security.username
-		--password $security.password
-		#end if
-
-		#if $proxy
-		--proxy $proxy
-		#end if
-
-		--timeout=600
-
-	</command>
-
-	<inputs>
-	
-    <param name="input_file" type="data" format="mgf" multiple="false" label="MSMS File" help="A Mascot Generic Format file containing MSMS Spectra"/>
-
-	<conditional name="database">
-		<param name="source_select" type="select" label="Database Type">
-			<option value="built_in">Built-In</option>
-			<option selected="true" value="custom_defined">Custom</option>
-		</param>
-		<when value="built_in">
-			<param name="dbkey" type="select" format="text" >
-				<label>Database</label>
-				<options from_file="mascot_databases.loc">
-					<column name="name" index="0" />
-					<column name="value" index="2" />
-				</options>
-			</param>
-		</when>
-		<when value="custom_defined">
-			<param name="custom_db" type="text" size="80" value="SwissProt" label="Database Name" help="Exact name of a database defined on the Mascot server (case-sensitive)"/>
-		</when>
-	</conditional>
-
-	<param name="variable_mods" format="text" type="select" multiple="true" label="Variable Modifications" help="Multiple values allowed">
-		<options from_file="mascot_mods.loc">
-			<column name="name" index="0" />
-			<column name="value" index="2" />
-		</options>
-	</param>		
-
-	<param name="fixed_mods" format="text" type="select" multiple="true" label="Fixed Modifications" help="Multiple values allowed">
-		<options from_file="mascot_mods.loc">
-			<column name="name" index="0" />
-			<column name="value" index="2" />
-		</options>
-	</param>
-	
-	<param name="missed_cleavages" type="select" format="text">
-		<label>Missed Cleavages Allowed</label>
-	    <option value="0">0</option>		
-		<option value="1">1</option>
-		<option selected="true" value="2">2</option>
-	</param>
-	
-	<param name="enzyme" type="select" format="text">
-	    <label>Enzyme</label>
-	    <option selected="true" value="Trypsin">Trypsin</option>
-	    <option value="Trypsin/P">Trypsin/P</option>
-	    <option value="Arg-C">Arg-C</option>
-	    <option value="Asp-N">Asp-N</option>
-	    <option value="Asp-N_ambic">Asp-N_ambic</option>
-	    <option value="Chymotrypsin">Chymotrypsin</option>
-	    <option value="CNBr">CNBr</option>
-	    <option value="CNBr+Trypsin">CNBr+Trypsin</option>
-	    <option value="Formic_acid">Formic_acid</option>
-	    <option value="Lys-C">Lys-C</option>
-	    <option value="Lys-C/P">Lys-C/P</option>
-	   	<option value="LysC+AspN">LysC+AspN</option>
-	   	<option value="Lys-N">Lys-N</option>
-	   	<option value="PepsinA">PepsinA</option>
-	   	<option value="semiTrypsin">semiTrypsin</option>
-	   	<option value="TrypChymo">TrypChymo</option>	   	   	
-	   	<option value="TrypsinMSIPI">TrypsinMSIPI</option>	
-	   	<option value="TrypsinMSIPI/P">TrypsinMSIPI/P</option>
-	   	<option value="V8-DE">V8-DE</option>
-	   	<option value="V8-E">V8-E</option>
-	   	<option value="none">none</option>	   	
-	</param>
-	
-	<param name="allowed_charges" type="select" format="text">
-	    <label>Peptide Charge</label>
-		<option value="8-">8-</option>
-		<option value="7-">7-</option>
-		<option value="6-">6-</option>
-		<option value="5-">5-</option>
-		<option value="4-">4-</option>
-		<option value="3-">3-</option>
-		<option value="2-,3- and 4-">2-,3- and 4-</option>
-		<option value="2- and 3-">2- and 3-</option>
-		<option value="2-">2-</option>
-		<option value="1-,2- and 3-">1-,2- and 3-</option>
-		<option value="1-">1-</option>
-		<option value="Mr">Mr</option>
-		<option value="1+">1+</option>
-	    <option value="1+, 2+ and 3+">1+,2+ and 3+</option>		
-		<option value="2+">2+</option>
-		<option value="2+ and 3+">2+ and 3+</option>
-		<option selected="true" value="2+,3+ and 4+">2+,3+ and 4+</option>
-		<option value="3+">3+</option>
-		<option value="4+">4+</option>
-		<option value="5+">5+</option>
-		<option value="6+">6+</option>
-		<option value="7+">7+</option>
-		<option value="8+">8+</option>
-	</param>
-	
-	<param name="instrument" type="select" format="text">
-	    <label>Instrument</label>
-		<option value="ESI-QUAD-TOF">ESI-QUAD-TOF</option>
-		<option value="MALDI-TOF-PSD">MALDI-TOF-PSD</option>
-		<option selected="true" value="ESI-TRAP">ESI-TRAP</option>
-		<option value="ESI-QUAD">ESI-QUAD</option>
-		<option value="ESI-FTICR">ESI-FTICR</option>
-	    <option value="MALDI-TOF-TOF">MALDI-TOF-TOF</option>
-		<option value="ESI-4SECTOR">ESI-4SECTOR</option>
-		<option value="FTMS-ECD">FTMS-ECD</option>
-		<option value="ETD-TRAP">ETD-TRAP</option>
-		<option value="MALDI-QUAD-TOF">MALDI-QUAD-TOF</option>
-		<option value="MALDI-QIT-TOF">MALDI-QIT-TOF</option>
-		<option value="MALDI-ISD">MALDI-ISD</option>
-		<option value="CID+ETD">CID+ETD</option>
-	</param>
-
-
-	<param name="quant_method" type="select" format="text">
-	    <label>Quantitation</label>
-		<option selected="true" value="None">None</option>
-		<option value="iTRAQ 4plex">iTRAQ 4plex</option>
-		<option value="iTRAQ 4plex (protein)">iTRAQ 4plex (protein)</option>
-		<option value="iTRAQ 8plex">iTRAQ 8plex</option>
-		<option value="TMT 6plex">TMT 6plex</option>
-		<option value="TMT 2plex">TMT 2plex</option>
-	    <option value="DiLeu 4plex">DiLeu 4plex</option>
-		<option value="18O multiplex">18O multiplex</option>
-		<option value="SILAC K+6 R+6 multiplex">SILAC K+6 R+6 multiplex</option>
-		<option value="IPTL (Succinyl and IMID) multiplex">IPTL (Succinyl and IMID) multiplex</option>
-		<option value="ICPL duplex pre-digest [MD]">ICPL duplex pre-digest [MD]</option>
-		<option value="ICPL duplex post-digest [MD]">ICPL duplex post-digest [MD]</option>
-		<option value="ICPL triplex pre-digest [MD]">ICPL triplex pre-digest [MD]</option>
-		<option value="ICPL quadruplex pre-digest [MD]">ICPL quadruplex pre-digest [MD]</option>
-		<option value="18O corrected [MD]">18O corrected [MD]</option>
-		<option value="15N Metabolic [MD]">15N Metabolic [MD]</option>
-		<option value="15N + 13C Metabolic [MD]">15N + 13C Metabolic [MD]</option>
-		<option value="SILAC K+6 R+10 [MD]">SILAC K+6 R+10 [MD]</option>
-		<option value="SILAC K+6 R+10 Arg-Pro [MD]">SILAC K+6 R+10 Arg-Pro [MD]</option>
-		<option value="SILAC K+6 R+6 [MD]">SILAC K+6 R+6 [MD]</option>
-		<option value="SILAC R+6 R+10 [MD]">SILAC R+6 R+10 [MD]</option>
-		<option value="SILAC K+8 R+10 [MD]">SILAC K+8 R+10 [MD]</option>		
-		<option value="SILAC K+4 K+8 R+6 R+10 [MD]">SILAC K+4 K+8 R+6 R+10 [MD]</option>
-		<option value="ICAT ABI Cleavable [MD]">ICAT ABI Cleavable [MD]</option>
-		<option value="ICAT D8 [MD]">ICAT D8 [MD]</option>
-		<option value="Dimethylation [MD]">Dimethylation [MD]</option>
-		<option value="NBS Shimadzu [MD]">NBS Shimadzu [MD]</option>
-		<option value="Acetylation [MD]">Acetylation [MD]</option>
-		<option value="Label-free [MD]">Label-free [MD]</option>
-	</param>	
-	
-	<param name="fragment_ion_tol" label="Fragment Ion Tolerance" type="float" value="0.5" min="0" max="10000" help="Fragment ion tolerance in Daltons"/>
-
-	<param name="precursor_ion_tol" label="Precursor Ion Tolerance (Da or ppm)" type="float" value="10" min="0" max="10000" help="Enter a value in Daltons or ppm depending on the units chosen below"/>
-	<param name="precursor_tolu" type="select" format="text">
-	    <label>Precursor Ion Tolerance Units</label>
-	    <option value="ppm">ppm</option>		
-		<option value="Da">Da</option>
-	</param>
-
-	<param name="server" type="text" label="URL to the cgi directory on the Mascot Server " size="60" value="http://www.exampleserver.com/mascot/cgi/"/>
-	<param name="proxy" type="text" label="Proxy Server URL including proxy port" size="60" value="" help="eg http://proxy.latrobe.edu.au:8080"/>
-
-	<conditional name="security">
-		<param name="security_use" type="boolean" label="Use Mascot Security?" help="Select this if you need to enter a username and password" truevalue="true" falsevalue="false" />
-		<when value="false" />
-		<when value="true">
-			<param name="username" type="text" label="Username" size="60" value="" help="Username on Mascot Server"/>
-			<param name="password" type="text" label="Password" size="60" value="" help="Mascot Password. Password is encrypted when over the internet but is stored in clear-text on the Galaxy server"/>
-		</when>
-	</conditional>
-	<param name="email" type="text" label="Email " size="60" value="" help=""/>
-	
-	
-
-  </inputs>
-  <outputs>
-    <data format="mascotdat" name="output" metadata_source="input_file" label="mascot_vs_${database.dbkey if $database.has_key('dbkey') else $database.custom_db}.${input_file.display_name}.mascotdat"/>
-  </outputs>
-
-  <help>
-	Run a Mascot MS/MS Ion Search
-  </help>
-
+        <conditional name="security">
+            <param name="security_use" type="boolean" label="Use Mascot Security?" help="Select this if you need to enter a username and password" truevalue="true" falsevalue="false" />
+            <when value="false" />
+            <when value="true">
+                <param name="username" type="text" label="Username" size="60" value="" help="Username on Mascot Server"/>
+                <param name="password" type="text" label="Password" size="60" value="" help="Mascot Password. Password is encrypted when over the internet but is stored in clear-text on the Galaxy server"/>
+            </when>
+        </conditional>
+        <param name="email" type="text" label="Email " size="60" value="" help=""/>
+    </inputs>
+    <outputs>
+        <data format="mascotdat" name="output" metadata_source="input_file" label="mascot_vs_${database.dbkey if $database.has_key('dbkey') else $database.custom_db}.${input_file.display_name}.mascotdat"/>
+    </outputs>
+    <help>
+        Run a Mascot MS/MS Ion Search
+    </help>
 </tool>

--- a/mascot/mascot.xml
+++ b/mascot/mascot.xml
@@ -1,11 +1,11 @@
 <tool id="proteomics_search_mascot_1" name="Mascot MSMS Search" version="1.1.0">
-
+	<description>Mascot MS/MS Search</description>
 	<requirements>
             <container type="docker">iracooke/protk-1.4.1</container>
 	    <requirement type="package" version="1.4">protk</requirement>
    </requirements>
 
-	<description>Mascot MS/MS Search</description>
+
 
 
 	<command>mascot_search.rb 

--- a/mascot/mascot.xml
+++ b/mascot/mascot.xml
@@ -2,7 +2,7 @@
     <description>Mascot MS/MS Search</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4.2">protk</requirement>
     </requirements>
     <command>mascot_search.rb 
 

--- a/mascot/mascot_to_pepxml.xml
+++ b/mascot/mascot_to_pepxml.xml
@@ -2,7 +2,7 @@
     <description>Converts a mascot results file to pepXML</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4.2">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
     </requirements>
     <command>mascot_to_pepxml.rb 

--- a/mascot/mascot_to_pepxml.xml
+++ b/mascot/mascot_to_pepxml.xml
@@ -1,11 +1,11 @@
 <tool id="mascot_to_pepxml_1" name="Mascot to pepXML" version="1.1.0">
+    <description>Converts a mascot results file to pepXML</description>
 	<requirements>
             <container type="docker">iracooke/protk-1.4.1</container>
 	    	<requirement type="package" version="1.4">protk</requirement>
 			<requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
    </requirements>
 
-  <description>Converts a mascot results file to pepXML</description>
 
 <command>mascot_to_pepxml.rb 
 	$input_file 

--- a/mascot/mascot_to_pepxml.xml
+++ b/mascot/mascot_to_pepxml.xml
@@ -1,83 +1,72 @@
 <tool id="mascot_to_pepxml_1" name="Mascot to pepXML" version="1.1.0">
     <description>Converts a mascot results file to pepXML</description>
-	<requirements>
-            <container type="docker">iracooke/protk-1.4.1</container>
-	    	<requirement type="package" version="1.4">protk</requirement>
-			<requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
-   </requirements>
+    <requirements>
+        <container type="docker">iracooke/protk-1.4.1</container>
+        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
+    </requirements>
+    <command>mascot_to_pepxml.rb 
+        $input_file 
 
+        -o $output 
 
-<command>mascot_to_pepxml.rb 
-	$input_file 
+        #if $database.source_select=="built_in":
+            -d $database.dbkey
+        #else 
+            -d $database.fasta_file
+        #end if
 
-	-o $output 
+        #if $explicit_enzyme.explicit_enzyme_use
+            --enzyme $explicit_enzyme.enzyme
+        #end if
 
-	#if $database.source_select=="built_in":
-	-d $database.dbkey
-	#else 
-	-d $database.fasta_file
-	#end if
+        $shortid
+    </command>
+    <inputs>
+        <param name="input_file" type="data" format="mascotdat" multiple="false" label="Input File" help="Mascot results file"/>
 
-	#if $explicit_enzyme.explicit_enzyme_use
-	--enzyme $explicit_enzyme.enzyme
-	#end if
+        <conditional name="database">
+            <param name="source_select" type="select" label="Database source" help="A local copy of the database used in the Mascot search">
+                <option value="built_in">Built-In</option>
+                <option value="input_ref">Uploaded fasta file</option>
+            </param>
+            <when value="built_in">
+                <param name="dbkey" type="select" format="text" >
+                    <label>Database</label>
+                    <options from_file="pepxml_databases.loc">
+                        <column name="name" index="0" />
+                        <column name="value" index="2" />
+                    </options>
+                </param>
+            </when>
+            <when value="input_ref">
+                <param name="fasta_file" type="data" format="fasta" label="Uploaded FASTA file" />
+            </when>
+        </conditional>
 
-	$shortid
+        <param name="shortid" type="boolean" label="Short ID" help="Use protein id from the Mascot result file instead reading from the fasta database." truevalue="--shortid" falsevalue="" />
 
-</command>
-<inputs>
+        <conditional name="explicit_enzyme">
+            <param name="explicit_enzyme_use" type="boolean" label="Specify Enzyme" help="If left unchecked the Enzyme will be read from the input file" truevalue="true" falsevalue="false" />
+            <when value="false" />
+            <when value="true">
+                <param name="enzyme" type="text" label="Enzyme" size="80" value="trypsin" help="Semi-cleavage can be specified as semisample_enyzme eg semitrypsin"/>
+            </when>
+        </conditional>
 
-
-	<param name="input_file" type="data" format="mascotdat" multiple="false" label="Input File" help="Mascot results file"/>
-
-	<conditional name="database">
-		<param name="source_select" type="select" label="Database source" help="A local copy of the database used in the Mascot search">
-			<option value="built_in">Built-In</option>
-			<option value="input_ref">Uploaded fasta file</option>
-		</param>
-		<when value="built_in">
-			<param name="dbkey" type="select" format="text" >
-				<label>Database</label>
-				<options from_file="pepxml_databases.loc">
-					<column name="name" index="0" />
-					<column name="value" index="2" />
-				</options>
-			</param>
-		</when>
-		<when value="input_ref">
-			<param name="fasta_file" type="data" format="fasta" label="Uploaded FASTA file" />
-		</when>
-	</conditional>
-
-	<param name="shortid" type="boolean" label="Short ID" help="Use protein id from the Mascot result file instead reading from the fasta database." truevalue="--shortid" falsevalue="" />
-
-	<conditional name="explicit_enzyme">
-		<param name="explicit_enzyme_use" type="boolean" label="Specify Enzyme" help="If left unchecked the Enzyme will be read from the input file" truevalue="true" falsevalue="false" />
-		<when value="false" />
-		<when value="true">
-			<param name="enzyme" type="text" label="Enzyme" size="80" value="trypsin" help="Semi-cleavage can be specified as semisample_enyzme eg semitrypsin"/>
-		</when>
-	</conditional>
-
-
-
-</inputs>
-<outputs>
-	<data format="raw_pepxml" metadata_source="input_file" name="output" label="${input_file.display_name}.pepXML" />
-</outputs>
-
-	<tests>
-    	<test>
-    		<param name="source_select" value="input_ref"/>
-	      	<param name="fasta_file" value="bsa.fasta"/>
-   		   	<param name="input_file" value="F002832.dat"/>
-      		<output name="output" file="bsa_mascot2xml.pep.xml" compare="sim_size" delta="600" /> 
-    	</test>
-    	
-  	</tests>
-
-<help>
-	Convert mascot results from mascotdat to pepXML
-</help>
-
+    </inputs>
+    <outputs>
+        <data format="raw_pepxml" metadata_source="input_file" name="output" label="${input_file.display_name}.pepXML" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="source_select" value="input_ref"/>
+              <param name="fasta_file" value="bsa.fasta"/>
+                  <param name="input_file" value="F002832.dat"/>
+              <output name="output" file="bsa_mascot2xml.pep.xml" compare="sim_size" delta="600" />
+        </test>
+    </tests>
+    <help>
+        Convert mascot results from mascotdat to pepXML
+    </help>
 </tool>

--- a/mascot/tool_dependencies.xml
+++ b/mascot/tool_dependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="protk" version="1.4.2">
+        <repository name="package_protk_1_4_2" owner="iuc"/>
+    </package>
+</tool_dependency>

--- a/msgfplus/msgfplus_search.xml
+++ b/msgfplus/msgfplus_search.xml
@@ -47,8 +47,7 @@
         --num-reported-matches=$num_reported_matches
         --java-mem=$java_mem
 
-        --threads $threads
-
+        --threads "\${GALAXY_SLOTS:-1}"
         #if $pepxml_output_use:
         --pepxml
         #end if
@@ -155,7 +154,6 @@
         <param name="max_pep_charge" help="" type="integer" value="3" label="Maximum Peptide Charge"/>
         <param name="num_reported_matches" help="Number of matches per spectrum to be reported" type="integer" value="1" label="Num reported matches"/>
         <param name="java_mem" help="Increase this value if you get out of memory errors" type="text" size="80" value="3500M" label="Java Memory Limit"/>
-        <param name="threads" type="integer" value="1" label="Threads" help="Number of threads to use for search."/>        
         <param name="pepxml_output_use" checked="true" type="boolean" label="Convert results to pepXML" help="" truevalue="true" falsevalue="false" />
     </inputs>
     <outputs>

--- a/msgfplus/msgfplus_search.xml
+++ b/msgfplus/msgfplus_search.xml
@@ -2,7 +2,7 @@
     <description>Run an MSGF+ Search</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4.2">protk</requirement>
         <requirement type="package" version="20140210">msgfplus</requirement>
         <requirement type="package" version="3_0_4388">proteowizard</requirement>
     </requirements>

--- a/msgfplus/tool_dependencies.xml
+++ b/msgfplus/tool_dependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="protk" version="1.4.2">
+        <repository name="package_protk_1_4_2" owner="iuc"/>
+    </package>
+</tool_dependency>

--- a/omssa/omssa.xml
+++ b/omssa/omssa.xml
@@ -1,184 +1,162 @@
 <tool id="proteomics_search_omssa_1" name="OMSSA MSMS Search" version="1.1.0">
-
-   <requirements>
+    <description>Run an OMSSA MS/MS Search</description>
+    <requirements>
         <container type="docker">iracooke/protk-1.4.1</container>
         <requirement type="package" version="1.4.2">protk</requirement>
-    	<requirement type="package" version="2.1.9">omssa</requirement>
-    	<requirement type="package" version="2.2.29">blast+</requirement>
-   </requirements>
+        <requirement type="package" version="2.1.9">omssa</requirement>
+        <requirement type="package" version="2.2.29">blast+</requirement>
+    </requirements>
+    <command>omssa_search.rb
 
+        #if $database.source_select=="built_in":
+            -d $database.dbkey 
+        #else
+            -d $database.fasta_file
+        #end if
+        --var-mods='
+        $variable_mods
+        '
 
-	<description>Run an OMSSA MS/MS Search</description>
-		
-	<command>omssa_search.rb
+        --fix-mods='
+        $fixed_mods
+        '
 
-		#if $database.source_select=="built_in":
-		-d $database.dbkey 
-		#else
-		-d $database.fasta_file
-		#end if
-		
-		--var-mods='
-		$variable_mods
-		'
-		
-		--fix-mods='
-		$fixed_mods
-		'
-		
-		--searched-ions='
-		$searched_ions
-		'
-		
-		$input_file 
-		-o $output 
-		-r 
+        --searched-ions='
+        $searched_ions
+        '
 
-		--enzyme=$enzyme 
+        $input_file 
+        -o $output 
+        -r 
 
-		--precursor-ion-tol-units=$precursor_tolu 
+        --enzyme=$enzyme 
+        --precursor-ion-tol-units=$precursor_tolu 
+        -v $missed_cleavages 
+        -f $fragment_ion_tol 
+        -p $precursor_ion_tol 
+        --num-peaks-for-multi-isotope-search $multi_isotope 
 
-		-v $missed_cleavages 
+        $use_average_mass 
+        $respect_precursor_charges 
 
-		-f $fragment_ion_tol 
+        --max-hit-expect $max_hit_expect 
+        --intensity-cut-off $intensity_cut_off
 
-		-p $precursor_ion_tol 
+    </command>
+    <inputs>
+        <conditional name="database">
+            <param name="source_select" type="select" label="Database source">
+                <option value="built_in">Built-In</option>
+                <option selected="true" value="input_ref">Uploaded fasta file</option>
+            </param>
+            <when value="built_in">
+                <param name="dbkey" type="select" format="text" >
+                    <label>Database</label>
+                    <options from_file="pepxml_databases.loc">
+                        <column name="name" index="0" />
+                        <column name="value" index="2" />
+                    </options>
+                </param>
+            </when>
+            <when value="input_ref">
+                <param name="fasta_file" type="data" format="fasta" label="Uploaded FASTA file" />
+            </when>
+        </conditional>
+        <param name="input_file" type="data" format="mgf" multiple="false" label="MSMS File" help="An mgf file with MS/MS data"/>        
+        <param name="variable_mods" format="text" type="select" multiple="true" label="Variable Modifications" help="Hold the appropriate key while
+            clicking to select multiple items">
+            <options from_file="omssa_mods.loc">
+                <column name="name" index="0" />
+                <column name="value" index="2" />
+            </options>
+        </param>
+        <param name="fixed_mods" format="text" type="select" multiple="true" label="Fixed Modifications"
+            help="Hold the appropriate key while clicking to select multiple items">
+            <options from_file="omssa_mods.loc">
+                <column name="name" index="0" />
+                <column name="value" index="2" />
+            </options>
+        </param>
+        <param name="missed_cleavages" type="select" format="text" help="Allow peptides to contain up to this many missed enzyme cleavage sites">
+            <label>Missed Cleavages Allowed</label>
+            <option value="0">0</option>
+            <option value="1">1</option>
+            <option selected="true" value="2">2</option>
+        </param>
+        <param name="enzyme" type="select" format="text">
+            <label>Enzyme</label>
+            <option value="0">Trypsin</option>
+            <option value="1">Arg-C</option>
+            <option value="2">CNBr</option>
+            <option value="3">Chymotrypsin (FYWL)</option>
+            <option value="4">Formic Acid</option>
+            <option value="5">Lys-C</option>
+            <option value="6">Lys-C, no P rule</option>
+            <option value="7">Pepsin A</option>
+            <option value="8">Trypsin+CNBr</option>
+            <option value="9">Trypsin+Chymotrypsin (FYWLKR)</option>
+            <option value="10">Trypsin, no P rule</option>
+            <option value="11">Whole protein</option>
+            <option value="12">Asp-N</option>
+            <option value="13">Glu-C</option>
+            <option value="14">Asp-N+Glu-C</option>
+            <option value="15">Top-Down</option>
+            <option value="16">Semi-Tryptic</option>
+            <option value="17">No Enzyme</option>
+            <option value="18">Chymotrypsin, no P rule (FYWL)</option>
+            <option value="19">Asp-N (DE)</option>
+            <option value="20">Glu-C (DE)</option>
+            <option value="21">Lys-N (K)</option>
+            <option value="22">Thermolysin, no P rule</option>
+            <option value="23">Semi-Chymotrypsin (FYWL)</option>
+            <option value="24">Semi-Glu-C</option>
+        </param>
 
-		--num-peaks-for-multi-isotope-search $multi_isotope 
+        <param name="fragment_ion_tol" help="Fragment Ion Tolerance in Daltons" type="float" value="0.5" min="0" max="10000" label="Fragment ion tolerance"/>
+        <param name="max_hit_expect" help="Expect values less than this are considered to be hits. Use a large value, eg 10000 when results will be processed downstream with Peptide Prophet" type="float" value="10000.0" min="0" max="10000000" label="Maximum Expect value allowed in the hit list"/><!-- -he-->
+        <param name="intensity_cut_off" help="Peak intensity cut-off as a fraction of maximum peak intensity" type="float" value="0.0005" min="0" max="1" label="Peak intensity cut-off"/><!-- -ci-->
 
-		$use_average_mass 
-		$respect_precursor_charges 
+        <param name="precursor_ion_tol" help="Precursor Ion Tolerance (Da or ppm)" type="float" value="10" min="0" max="10000" label="Precursor ion tolerance"/>
+        <param name="precursor_tolu" type="select" format="text">
+            <label>Precursor Ion Tolerance Units</label>
+            <option value="ppm">ppm</option>
+            <option value="Da">Da</option>
+        </param>
 
-		--max-hit-expect $max_hit_expect 
+        <param name="use_average_mass" type="boolean" label="Use average precursor masses" help="Match precursor to average mass of the parent ion instead of its monoisotopic mass" truevalue="-a average" falsevalue=""/>
+        <param name="respect_precursor_charges" type="boolean" label="Respect precursor charges" help="Use precursor charge information in input file rather than OMSSA's inferred value" truevalue="--respect-charges" falsevalue=""/>
 
-		--intensity-cut-off $intensity_cut_off
+        <param name="multi_isotope" type="select" format="text" help="Include this many neighbouring peaks when searching for a match to the precursor mass. Only used when doing monoisotopic search">
+            <label>Multi-isotope search.</label>
+            <option value="0">0</option>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+        </param>
 
-	</command>
-	
+        <param name="searched_ions" display="checkboxes" type="select" multiple="true" format="text" label="Ions included in search" help="">
+            <option value="0">a</option>
+            <option selected="true" value="1">b</option>
+            <option value="2">c</option>
+            <option value="3">x</option>
+            <option selected="true" value="4">y</option>
+            <option value="5">zdot</option>
+            <option value="10">adot</option>
+            <option value="11">x-CO2</option>
+            <option value="12">adot-CO2</option>
+        </param>
 
-	<inputs>	
-		<conditional name="database">
-			<param name="source_select" type="select" label="Database source">
-				<option value="built_in">Built-In</option>
-				<option selected="true" value="input_ref">Uploaded fasta file</option>
-			</param>
-			<when value="built_in">
-				<param name="dbkey" type="select" format="text" >
-					<label>Database</label>
-					<options from_file="pepxml_databases.loc">
-						<column name="name" index="0" />
-						<column name="value" index="2" />
-					</options>
-				</param>
-			</when>
-			<when value="input_ref">
-				<param name="fasta_file" type="data" format="fasta" label="Uploaded FASTA file" />
-			</when>
-		</conditional>
-		
-		<param name="input_file" type="data" format="mgf" multiple="false" label="MSMS File" help="An mgf file with MS/MS data"/>		
-
-		<param name="variable_mods" format="text" type="select" multiple="true" label="Variable Modifications" help="Hold the appropriate key while
-			clicking to select multiple items">
-			<options from_file="omssa_mods.loc">
-				<column name="name" index="0" />
-				<column name="value" index="2" />
-			</options>
-		</param>		
-
-		<param name="fixed_mods" format="text" type="select" multiple="true" label="Fixed Modifications" help="Hold the appropriate key while
-		clicking to select multiple items">
-			<options from_file="omssa_mods.loc">
-				<column name="name" index="0" />
-				<column name="value" index="2" />
-			</options>
-		</param>
-
-		
-		<param name="missed_cleavages" type="select" format="text" help="Allow peptides to contain up to this many missed enzyme cleavage sites">
-			<label>Missed Cleavages Allowed</label>
-		    <option value="0">0</option>		
-			<option value="1">1</option>
-			<option selected="true" value="2">2</option>
-		</param>
-
-		<param name="enzyme" type="select" format="text">
-		    <label>Enzyme</label>
-		    <option value="0">Trypsin</option>
-			<option value="1">Arg-C</option>
-			<option value="2">CNBr</option>
-			<option value="3">Chymotrypsin (FYWL)</option>
-			<option value="4">Formic Acid</option>
-			<option value="5">Lys-C</option>
-			<option value="6">Lys-C, no P rule</option>
-			<option value="7">Pepsin A</option>
-			<option value="8">Trypsin+CNBr</option>
-			<option value="9">Trypsin+Chymotrypsin (FYWLKR)</option>
-			<option value="10">Trypsin, no P rule</option>
-			<option value="11">Whole protein</option>
-			<option value="12">Asp-N</option>
-			<option value="13">Glu-C</option>
-			<option value="14">Asp-N+Glu-C</option>
-			<option value="15">Top-Down</option>
-			<option value="16">Semi-Tryptic</option>
-			<option value="17">No Enzyme</option>
-			<option value="18">Chymotrypsin, no P rule (FYWL)</option>
-			<option value="19">Asp-N (DE)</option>
-			<option value="20">Glu-C (DE)</option>
-			<option value="21">Lys-N (K)</option>
-			<option value="22">Thermolysin, no P rule</option>
-			<option value="23">Semi-Chymotrypsin (FYWL)</option>
-			<option value="24">Semi-Glu-C</option>
-		</param>
-
-		<param name="fragment_ion_tol" help="Fragment Ion Tolerance in Daltons" type="float" value="0.5" min="0" max="10000" label="Fragment ion tolerance"/>
-		<param name="max_hit_expect" help="Expect values less than this are considered to be hits. Use a large value, eg 10000 when results will be processed downstream with Peptide Prophet" type="float" value="10000.0" min="0" max="10000000" label="Maximum Expect value allowed in the hit list"/><!-- -he-->
-		<param name="intensity_cut_off" help="Peak intensity cut-off as a fraction of maximum peak intensity" type="float" value="0.0005" min="0" max="1" label="Peak intensity cut-off"/><!-- -ci-->
-
-
-		<param name="precursor_ion_tol" help="Precursor Ion Tolerance (Da or ppm)" type="float" value="10" min="0" max="10000" label="Precursor ion tolerance"/>
-		<param name="precursor_tolu" type="select" format="text">
-		    <label>Precursor Ion Tolerance Units</label>
-		    <option value="ppm">ppm</option>		
-			<option value="Da">Da</option>
-		</param>
-		
-		<param name="use_average_mass" type="boolean" label="Use average precursor masses" help="Match precursor to average mass of the parent ion instead of its monoisotopic mass" truevalue="-a average" falsevalue=""/>
-		<param name="respect_precursor_charges" type="boolean" label="Respect precursor charges" help="Use precursor charge information in input file rather than OMSSA's inferred value" truevalue="--respect-charges" falsevalue=""/>
-		
-		<param name="multi_isotope" type="select" format="text" help="Include this many neighbouring peaks when searching for a match to the precursor mass. Only used when doing monoisotopic search">
-			<label>Multi-isotope search.</label>
-		    <option value="0">0</option>
-			<option value="1">1</option>
-			<option value="2">2</option>
-			<option value="3">3</option>
-			<option value="4">4</option>
-		</param>
-
-		<param name="searched_ions" display="checkboxes" type="select" multiple="true" format="text" label="Ions included in search" help="">
-		    <option value="0">a</option>
-			<option selected="true" value="1">b</option>
-			<option value="2">c</option>
-			<option value="3">x</option>
-			<option selected="true" value="4">y</option>
-			<option value="5">zdot</option>
-			<option value="10">adot</option>
-			<option value="11">x-CO2</option>
-			<option value="12">adot-CO2</option>
-		</param>
-		
-	</inputs>
-
-	<outputs>
-		<data format="raw_pepxml" name="output" metadata_source="input_file" label="omssa_vs_${database.dbkey if $database.has_key('dbkey') else $database.fasta_file.display_name}.${input_file.display_name}.pepXML"/>
-	</outputs>
-
-	<tests>
-		<!-- Just test that the tool runs and produces vaguely correct output -->
-		<test>
-		    <param name="source_select" value="input_ref"/>
-		    <param name="fasta_file" value="AASequences.fasta" format="fasta"/>
-		    <param name="input_file" value="mr176-BSA100fmole_BA3_01_8168.d.mgf" format="mgf"/>
+    </inputs>
+    <outputs>
+        <data format="raw_pepxml" name="output" metadata_source="input_file" label="omssa_vs_${database.dbkey if $database.has_key('dbkey') else $database.fasta_file.display_name}.${input_file.display_name}.pepXML"/>
+    </outputs>
+    <tests>
+        <!-- Just test that the tool runs and produces vaguely correct output -->
+        <test>
+            <param name="source_select" value="input_ref"/>
+            <param name="fasta_file" value="AASequences.fasta" format="fasta"/>
+            <param name="input_file" value="mr176-BSA100fmole_BA3_01_8168.d.mgf" format="mgf"/>
             <param name="max_hit_expect" value="1000"/>
             <param name="precursor_ion_tol" value="1.2"/>
             <param name="precursor_tolu" value="Da"/>
@@ -186,15 +164,15 @@
             <param name="variable_mods" value="1"/>
 
 
-		    <output name="output" format="raw_pepxml">
-		        <assert_contents>
-					<has_text text="VLFSQAQVYELERRFK" />
-		        </assert_contents>
-		    </output>
-		</test>
-	</tests>
+            <output name="output" format="raw_pepxml">
+                <assert_contents>
+                    <has_text text="VLFSQAQVYELERRFK" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 
-	<help>
+    <help>
 **What it does**
 
 Runs an MS/MS database search using the OMSSA search engine. Output is in the form of a pepXML file containing identified peptides along with their raw search scores.
@@ -207,5 +185,5 @@ If you use this tool please read and cite the paper describing OMSSA.
 
 Geer L. Y., et al. “Open mass spectrometry search algorithm” *J. Proteome Res.* 3(5), 958-964 (2004).
 
-	</help>
+    </help>
 </tool>

--- a/omssa/omssa.xml
+++ b/omssa/omssa.xml
@@ -2,7 +2,7 @@
 
    <requirements>
         <container type="docker">iracooke/protk-1.4.1</container>
-	    <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4.2">protk</requirement>
     	<requirement type="package" version="2.1.9">omssa</requirement>
     	<requirement type="package" version="2.2.29">blast+</requirement>
    </requirements>

--- a/omssa/tool_dependencies.xml
+++ b/omssa/tool_dependencies.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0"?>
 <tool_dependency>
-
     <package name="blast+" version="2.2.29">
         <repository name="package_blast_plus_2_2_29" owner="iuc" />
     </package>
-
+    <package name="protk" version="1.4.2">
+        <repository name="package_protk_1_4_2" owner="iuc" />
+    </package>
 </tool_dependency>

--- a/protk-proteogenomics/gff3_to_fasta.xml
+++ b/protk-proteogenomics/gff3_to_fasta.xml
@@ -1,10 +1,9 @@
 <tool id="gff3_to_fasta" name="Extract proteins from gff3" version="1.1.0">
-	<requirements>
+    <description>Extract proteins from gff3 and encode genomic coordinates in the fasta header</description>
+    <requirements>
         <container type="docker">iracooke/protk-1.4.1</container>		
 	    <requirement type="package" version="1.4">protk</requirement>
    </requirements>
-
-	<description>Extract proteins from gff3 and encode genomic coordinates in the fasta header</description>
 
 	<command>
 		augustus_to_proteindb.rb $gff_file -o $output $coords

--- a/protk-proteogenomics/gff3_to_fasta.xml
+++ b/protk-proteogenomics/gff3_to_fasta.xml
@@ -2,7 +2,7 @@
     <description>Extract proteins from gff3 and encode genomic coordinates in the fasta header</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4.2">protk</requirement>
    </requirements>
     <stdio>
         <exit_code range="1:"   level="fatal"   description="Failure" />
@@ -10,7 +10,6 @@
     <command>
         augustus_to_proteindb.rb $gff_file -o $output $coords
     </command>
-
     <inputs>
         <param name="gff_file" type="data" format="gff3" label="Augustus Generated gff3 File" />
         <param name="coords" type="boolean" label="Write genomic coordinates" help="" truevalue="--info" falsevalue="" />

--- a/protk-proteogenomics/gff3_to_fasta.xml
+++ b/protk-proteogenomics/gff3_to_fasta.xml
@@ -1,39 +1,30 @@
 <tool id="gff3_to_fasta" name="Extract proteins from gff3" version="1.1.0">
     <description>Extract proteins from gff3 and encode genomic coordinates in the fasta header</description>
     <requirements>
-        <container type="docker">iracooke/protk-1.4.1</container>		
-	    <requirement type="package" version="1.4">protk</requirement>
+        <container type="docker">iracooke/protk-1.4.1</container>
+        <requirement type="package" version="1.4">protk</requirement>
    </requirements>
+    <stdio>
+        <exit_code range="1:"   level="fatal"   description="Failure" />
+    </stdio>
+    <command>
+        augustus_to_proteindb.rb $gff_file -o $output $coords
+    </command>
 
-	<command>
-		augustus_to_proteindb.rb $gff_file -o $output $coords
-	</command>
-
-
-
-
-	<stdio>
-		<exit_code range="1:"   level="fatal"   description="Failure" />
-	</stdio>
-
-	<inputs>	
-		<param name="gff_file" type="data" format="gff3" label="Augustus Generated gff3 File" />
-		<param name="coords" type="boolean" label="Write genomic coordinates" help="" truevalue="--info" falsevalue="" />
-	</inputs>
-
-	<outputs>
-		<data format="fasta" name="output" />
-	</outputs>
-
-	<tests>
-	  <!-- Just test that the tool runs and produces vaguely correct output -->
-	  <test>
-	      <param name="gff_file" value="augustus_sample.gff" format="gff3"/>
-	      <output name="output" file="augustus_sample.fasta" format="fasta"/>
-	  </test>
-	</tests>
-
-
+    <inputs>
+        <param name="gff_file" type="data" format="gff3" label="Augustus Generated gff3 File" />
+        <param name="coords" type="boolean" label="Write genomic coordinates" help="" truevalue="--info" falsevalue="" />
+    </inputs>
+    <outputs>
+        <data format="fasta" name="output" />
+    </outputs>
+    <tests>
+      <!-- Just test that the tool runs and produces vaguely correct output -->
+      <test>
+          <param name="gff_file" value="augustus_sample.gff" format="gff3"/>
+          <output name="output" file="augustus_sample.fasta" format="fasta"/>
+      </test>
+    </tests>
   <help>
 
 **What it does**
@@ -41,11 +32,5 @@
 Extract proteins from gff3 and encode genomic coordinates in the fasta header.
 Currently this only works with gff3 generated using the Augustus gene finder
 
-----
-
-**References**
-
-
   </help>
-
 </tool>

--- a/protk-proteogenomics/protxml_to_gff.xml
+++ b/protk-proteogenomics/protxml_to_gff.xml
@@ -2,7 +2,7 @@
     <description>Export Proteomics Data to GFF</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4.2">protk</requirement>
         <requirement type="package" version="2.2.29">blast+</requirement>
     </requirements>
     <stdio>

--- a/protk-proteogenomics/protxml_to_gff.xml
+++ b/protk-proteogenomics/protxml_to_gff.xml
@@ -1,102 +1,78 @@
 <tool id="protxml_to_gff" name="Proteomics to GFF" version="1.1.0">
-	<description>Export Proteomics Data to GFF</description>
+    <description>Export Proteomics Data to GFF</description>
+    <requirements>
+        <container type="docker">iracooke/protk-1.4.1</container>
+        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="2.2.29">blast+</requirement>
+    </requirements>
+    <stdio>
+        <exit_code range="1:"   level="fatal"   description="Failure" />
+    </stdio>
+    <command>
+        protxml_to_gff.rb $protxml_file 
+            #if $database.source_select=="built_in":
+                -d $database.dbkey
+            #else 
+                -d $database.fasta_file
+            #end if
+            -c $gene_file
+            --gff-idregex='$gffidpattern'
+            -o $output
+    </command>
+    <inputs>
+        <conditional name="database">
+            <param name="source_select" type="select" label="Database source used for Proteomics Searches" help="Database should be an amino acid fasta file with entry id's that can be parsed to obtain contig or scaffold ids referenced in your gff file">
+                <option value="input_ref">Your Upload File</option>
+                <option value="built_in">Built-In</option>
+            </param>
+            <when value="built_in">
+                <param name="dbkey" type="select" format="text" >
+                    <label>Database</label>
+                    <options from_file="pepxml_databases.loc">
+                        <column name="name" index="0" />
+                        <column name="value" index="2" />
+                    </options>
+                </param>
+            </when>
+            <when value="input_ref">
+                <param name="fasta_file" type="data" format="fasta" label="Uploaded FASTA file" />
+            </when>
+        </conditional>
+        <param name="protxml_file" type="data" format="protxml" multiple="false" label="Proteomics Search Results" help="A ProtXML file produced by Protein Prophet"/>
+        <param name="gene_file" type="data" format="gff3" multiple="false" label="Protein coordinates" help="A gff3 file with coordinates for all protein entries used for proteomics searches. Coordinates should correspond to entries in the genome fasta file"/>
+        <param name="gffidpattern" size="40" type="text" value="lcl\|([^ ]*)" label="gff id regex" help="Regex with capture group for parsing gff ids from protein ids">
+            <sanitizer>
+            <valid initial="string.printable">
+             <remove value="&apos;"/>
+            </valid>
+            <mapping initial="none">
+              <add source="&apos;" target="__sq__"/>
+            </mapping>
+              </sanitizer>
+        </param>
+    </inputs>
+    <outputs>
+        <data format="gff3" name="output" />
+    </outputs>
+    <tests>
+      <test>
+          <param name="source_select" value="input_ref"/>
+          <param name="fasta_file" value="small_prot.fasta" format="fasta"/>
 
-	<requirements>
-		<container type="docker">iracooke/protk-1.4.1</container>		
-		<requirement type="package" version="1.4">protk</requirement>
-		<requirement type="package" version="2.2.29">blast+</requirement>
-   </requirements>
-
-	<command>
-		protxml_to_gff.rb $protxml_file 
-		
-		#if $database.source_select=="built_in":
-		-d $database.dbkey
-		#else 
-		-d $database.fasta_file
-		#end if
-
-		-c $gene_file
-
-		--gff-idregex='$gffidpattern'
-		
-		-o $output
-
-
-	</command>
-
-	<stdio>
-		<exit_code range="1:"   level="fatal"   description="Failure" />
-	</stdio>
-
-	<inputs>	
-		<conditional name="database">
-			<param name="source_select" type="select" label="Database source used for Proteomics Searches" help="Database should be an amino acid fasta file with entry id's that can be parsed to obtain contig or scaffold ids referenced in your gff file">
-				<option value="input_ref">Your Upload File</option>
-				<option value="built_in">Built-In</option>
-			</param>
-			<when value="built_in">
-				<param name="dbkey" type="select" format="text" >
-					<label>Database</label>
-					<options from_file="pepxml_databases.loc">
-						<column name="name" index="0" />
-						<column name="value" index="2" />
-					</options>
-				</param>
-			</when>
-			<when value="input_ref">
-				<param name="fasta_file" type="data" format="fasta" label="Uploaded FASTA file" />
-			</when>
-		</conditional>
-		
-		<param name="protxml_file" type="data" format="protxml" multiple="false" label="Proteomics Search Results" help="A ProtXML file produced by Protein Prophet"/>
-
-		<param name="gene_file" type="data" format="gff3" multiple="false" label="Protein coordinates" help="A gff3 file with coordinates for all protein entries used for proteomics searches. Coordinates should correspond to entries in the genome fasta file"/>
-
-		<param name="gffidpattern" size="40" type="text" value="lcl\|([^ ]*)" label="gff id regex" help="Regex with capture group for parsing gff ids from protein ids">
-	    	<sanitizer>
-        	<valid initial="string.printable">
-         	<remove value="&apos;"/>
-        	</valid>
-        	<mapping initial="none">
-          	<add source="&apos;" target="__sq__"/>
-        	</mapping>
-      		</sanitizer>
-	    </param>
-
-	</inputs>
-
-	<outputs>
-		<data format="gff3" name="output" />
-	</outputs>
-
-
-	<tests>
-	  <test>
-	  	<param name="source_select" value="input_ref"/>
-	  	<param name="fasta_file" value="small_prot.fasta" format="fasta"/>
-
-	      <param name="protxml_file" value="small.prot.xml" format="protxml"/>
-	      <param name="gene_file" value="small_combined.gff" format="gff3"/>
-	      <output name="output" format="gff3">
-	          <assert_contents>
-	              <has_text text="polypeptide" />
-	          </assert_contents>
-	      </output>
-	  </test>
-	</tests>
-
-  <help>
+          <param name="protxml_file" value="small.prot.xml" format="protxml"/>
+          <param name="gene_file" value="small_combined.gff" format="gff3"/>
+          <output name="output" format="gff3">
+              <assert_contents>
+                  <has_text text="polypeptide" />
+              </assert_contents>
+          </output>
+      </test>
+    </tests>
+    <help>
 
 **What it does**
 
 Exports peptides and proteins to gff
 
-----
-
-**References**
-
-
-  </help>
-
+    </help>
 </tool>

--- a/protk-proteogenomics/tool_dependencies.xml
+++ b/protk-proteogenomics/tool_dependencies.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0"?>
 <tool_dependency>
-
     <package name="blast+" version="2.2.29">
         <repository name="package_blast_plus_2_2_29" owner="iuc" />
     </package>
-
+    <package name="protk" version="1.4.2">
+        <repository name="package_protk_1_4_2" owner="iuc"/>
+    </package>
 </tool_dependency>

--- a/sixframe-translate/sixframe_translate.xml
+++ b/sixframe-translate/sixframe_translate.xml
@@ -8,16 +8,16 @@
         <exit_code range="1:" level="fatal" description="Failure" />
     </stdio>
     <command>
-        sixframe.rb 
+        sixframe.rb
         $fasta_file
-        -o $output 
-        $strip_header 
+        -o $output
+        $strip_header
         $coords
-        $peptideshaker 
+        $peptideshaker
         --min-len $minlen
 
         #if $gffoutput:
-        --gff
+            --gff
         #end if
     </command>
     <inputs>

--- a/sixframe-translate/sixframe_translate.xml
+++ b/sixframe-translate/sixframe_translate.xml
@@ -2,8 +2,8 @@
     <description>Translates DNA/RNA to protein</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.2</container>
-        <requirement type="package" version="1.4">protk</requirement>
-   </requirements>
+        <requirement type="package" version="1.4.2">protk</requirement>
+    </requirements>
     <stdio>
         <exit_code range="1:" level="fatal" description="Failure" />
     </stdio>

--- a/sixframe-translate/sixframe_translate.xml
+++ b/sixframe-translate/sixframe_translate.xml
@@ -1,11 +1,9 @@
 <tool id="sixframe_translate" name="Generate 6-frame translation" version="1.1.0">
-	<requirements>
-        <container type="docker">iracooke/protk-1.4.2</container>		
+    <description>Translates DNA/RNA to protein</description>
+    <requirements>
+        <container type="docker">iracooke/protk-1.4.2</container>
 	    <requirement type="package" version="1.4">protk</requirement>
    </requirements>
-
-	<description>Translates DNA/RNA to protein</description>
-
 	<command>
 		sixframe.rb 
 		$fasta_file

--- a/sixframe-translate/sixframe_translate.xml
+++ b/sixframe-translate/sixframe_translate.xml
@@ -2,72 +2,54 @@
     <description>Translates DNA/RNA to protein</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.2</container>
-	    <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4">protk</requirement>
    </requirements>
-	<command>
-		sixframe.rb 
-		$fasta_file
-		-o $output 
-		$strip_header 
-		$coords
-		$peptideshaker 
-		--min-len $minlen
+    <stdio>
+        <exit_code range="1:" level="fatal" description="Failure" />
+    </stdio>
+    <command>
+        sixframe.rb 
+        $fasta_file
+        -o $output 
+        $strip_header 
+        $coords
+        $peptideshaker 
+        --min-len $minlen
 
-		#if $gffoutput:
-		--gff
-		#end if
-
-	</command>
-
-
-
-	<stdio>
-		<exit_code range="1:"   level="fatal"   description="Failure" />
-	</stdio>
-
-	<inputs>	
-		<param name="fasta_file" type="data" format="fasta" label="Uploaded FASTA file" />
-		<param name="strip_header" type="boolean" label="Strip header info" help="" truevalue="--strip-header" falsevalue="" />
-		<param name="gffoutput" type="boolean" label="Produce gff instead of fasta" help="" truevalue="true" falsevalue="false" />
-
-		<param name="coords" type="boolean" label="Write genomic coordinates" help="" truevalue="--coords" falsevalue="" />
-
-		<param name="peptideshaker" type="boolean" label="Format fasta entries for PeptideShaker" help="" truevalue="--peptideshaker" falsevalue="" />
-
-		<param name="minlen" type="integer" value="20" min="1" label="Minimum Peptide Length"/>
-	</inputs>
-
-	<outputs>
-		<data format="fasta" name="output">
+        #if $gffoutput:
+        --gff
+        #end if
+    </command>
+    <inputs>
+        <param name="fasta_file" type="data" format="fasta" label="Uploaded FASTA file" />
+        <param name="strip_header" type="boolean" label="Strip header info" help="" truevalue="--strip-header" falsevalue="" />
+        <param name="gffoutput" type="boolean" label="Produce gff instead of fasta" help="" truevalue="true" falsevalue="false" />
+        <param name="coords" type="boolean" label="Write genomic coordinates" help="" truevalue="--coords" falsevalue="" />
+        <param name="peptideshaker" type="boolean" label="Format fasta entries for PeptideShaker" help="" truevalue="--peptideshaker" falsevalue="" />
+        <param name="minlen" type="integer" value="20" min="1" label="Minimum Peptide Length"/>
+    </inputs>
+    <outputs>
+        <data format="fasta" name="output">
             <change_format>
                 <when input="gffoutput" value="true" format="gff3" />
             </change_format>
         </data>
-	</outputs>
-
-	<tests>
-	  <test>
-	      <param name="fasta_file" value="small_genome.fasta" format="fasta"/>
-	      <output name="output" format="fasta">
-	          <assert_contents>
-	              <has_text text="SVQHWFYRFQAGHPRVFCPKNGPRRLW" />
-	          </assert_contents>
-	      </output>
-	  </test>
-	</tests>
-
-
-  <help>
+    </outputs>
+    <tests>
+      <test>
+          <param name="fasta_file" value="small_genome.fasta" format="fasta"/>
+          <output name="output" format="fasta">
+              <assert_contents>
+                  <has_text text="SVQHWFYRFQAGHPRVFCPKNGPRRLW" />
+              </assert_contents>
+          </output>
+      </test>
+    </tests>
+    <help>
 
 **What it does**
 
 Generates 6 frame translations suitable for proteogenomics workflows
 
-----
-
-**References**
-
-
-  </help>
-
+    </help>
 </tool>

--- a/sixframe-translate/tool_dependencies.xml
+++ b/sixframe-translate/tool_dependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="protk" version="1.4.2">
+        <repository name="package_protk_1_4_2" owner="iuc"/>
+    </package>
+</tool_dependency>

--- a/spectrast/spectrast_create.xml
+++ b/spectrast/spectrast_create.xml
@@ -5,14 +5,10 @@
         <requirement type="package" version="1.4">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
    </requirements>
-   
-
-
     <stdio>
         <exit_code range="1:" level="fatal" description="Job Failed" />
     </stdio>
-
-	<command>
+    <command>
         spectrast_create.rb --galaxy 
 
         #for $pepxml_file in $pepxml_files:
@@ -35,26 +31,21 @@
 
         echo "Spectral Library Primary File" > $output
 
-	</command>
-
-	<inputs>
+    </command>
+    <inputs>
 
         <param name="pepxml_files" multiple="true" type="data" format="pepxml,peptideprophet_pepxml,interprophet_pepxml" label="PepXML Files to use in library generation" help=""/>
-	
         <param name="spectrum_files" multiple="true" type="data" format="mzml" label="Data files containing spectra referred to in pepxml files" help=""/>
-
         <param name="decoy_prefix_string" help="String to identify decoys. All decoys wil be excluded" type="text" value="decoy" label="Decoy String" size="20"/> 
-
-        <param name="instrument_acquisition" help="Set the instrument and acquisition settings of the spectra (in case not specified in data files).
-                                 Examples: CID, ETD, CID-QTOF, HCD. The latter two are treated as high-mass accuracy spectra." type="text" value="CID-QTOF" label="Decoy String" size="20"/>
-
-        <param name="p_thresh" help="Matches scoring less than this value are discarded" type="float" value="0.99" min="0" max="1" label="Probability Threshold"/>
-	
+        <param name="instrument_acquisition" type="text" value="CID-QTOF" label="Decoy String" size="20" 
+            help="Set the instrument and acquisition settings of the spectra (in case not specified in data files).
+            Examples: CID, ETD, CID-QTOF, HCD. The latter two are treated as high-mass accuracy spectra."/>
+        <param name="p_thresh" type="float" value="0.99" min="0" max="1" label="Probability Threshold"
+            help="Matches scoring less than this value are discarded" />
     </inputs>
-
-      <outputs>
+    <outputs>
         <data format="splib" name="output"/>
-      </outputs>
+    </outputs>
     <help>
 <![CDATA[
 **What it does**

--- a/spectrast/spectrast_create.xml
+++ b/spectrast/spectrast_create.xml
@@ -9,28 +9,31 @@
         <exit_code range="1:" level="fatal" description="Job Failed" />
     </stdio>
     <command>
-        spectrast_create.rb --galaxy 
+<![CDATA[
+        spectrast_create.rb --galaxy
 
         #for $pepxml_file in $pepxml_files:
-        ${pepxml_file}
+            ${pepxml_file}
         #end for
 
         --spectrum-files='$spectrum_files'
-
         --predicate 'Protein!~$decoy_prefix_string'
-
         --p-thresh $p_thresh
-
         --instrument-acquisition $instrument_acquisition
+        -o library
 
-        -o library;
+        &&
 
-        mkdir -p $output.files_path;
+        mkdir -p $output.files_path
 
-        cp library.splib library.spidx library.pepidx  $output.files_path/;
+        &&
+
+        cp library.splib library.spidx library.pepidx  $output.files_path/
+
+        &&
 
         echo "Spectral Library Primary File" > $output
-
+]]>
     </command>
     <inputs>
 

--- a/spectrast/spectrast_create.xml
+++ b/spectrast/spectrast_create.xml
@@ -25,9 +25,9 @@
 
         -o library;
 
-        mkdir -p $output.extra_files_path;
+        mkdir -p $output.files_path;
 
-        cp library.splib library.spidx library.pepidx  $output.extra_files_path/;
+        cp library.splib library.spidx library.pepidx  $output.files_path/;
 
         echo "Spectral Library Primary File" > $output
 

--- a/spectrast/spectrast_create.xml
+++ b/spectrast/spectrast_create.xml
@@ -2,7 +2,7 @@
     <description>Create Spectral Libraries</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.2</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4.2">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
    </requirements>
     <stdio>

--- a/spectrast/spectrast_create.xml
+++ b/spectrast/spectrast_create.xml
@@ -1,11 +1,12 @@
 <tool id="spectrast_create_1" name="SpectraST Create" version="1.0.0">
+    <description>Create Spectral Libraries</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.2</container>
         <requirement type="package" version="1.4">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
    </requirements>
    
-	<description>Create Spectral Libraries</description>
+
 
     <stdio>
         <exit_code range="1:" level="fatal" description="Job Failed" />

--- a/spectrast/spectrast_create.xml
+++ b/spectrast/spectrast_create.xml
@@ -55,5 +55,12 @@
       <outputs>
         <data format="splib" name="output"/>
       </outputs>
+    <help>
+<![CDATA[
+**What it does**
 
+Create Spectral Libraries.
+
+]]>
+    </help>
 </tool>

--- a/spectrast/spectrast_filter.xml
+++ b/spectrast/spectrast_filter.xml
@@ -1,13 +1,11 @@
 <tool id="spectrast_filter_1" name="SpectraST Filter" version="1.0.0">
+    <description>Filter and Manipulate Spectral Libraries</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.2</container>
         <requirement type="package" version="1.4">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
    </requirements>
-   
-	<description>Filter and Manipulate Spectral Libraries</description>
-
-    <stdio>
+   <stdio>
         <exit_code range="1:" level="fatal" description="Job Failed" />
     </stdio>
 

--- a/spectrast/spectrast_filter.xml
+++ b/spectrast/spectrast_filter.xml
@@ -18,8 +18,8 @@
         --replicates $replicates
         -o library;
 
-        mkdir -p ${output.extra_files_path};
-        cp library.splib library.spidx library.pepidx  ${output.extra_files_path}/;
+        mkdir -p ${output.files_path};
+        cp library.splib library.spidx library.pepidx  ${output.files_path}/;
 
         echo "Spectral Library Primary File" > $output
     </command>

--- a/spectrast/spectrast_filter.xml
+++ b/spectrast/spectrast_filter.xml
@@ -56,5 +56,7 @@
       <outputs>
         <data format="splib" name="output"/>
       </outputs>
-
+    <help>
+        Filter and Manipulate Spectral Libraries
+    </help>
 </tool>

--- a/spectrast/spectrast_filter.xml
+++ b/spectrast/spectrast_filter.xml
@@ -4,37 +4,27 @@
         <container type="docker">iracooke/protk-1.4.2</container>
         <requirement type="package" version="1.4">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
-   </requirements>
-   <stdio>
+    </requirements>
+    <stdio>
         <exit_code range="1:" level="fatal" description="Job Failed" />
     </stdio>
-
-	<command>
+    <command>
         spectrast_filter.rb  --merge $merge
 
-
         #for $splib_file in $splib_files:
-        ${splib_file.extra_files_path}/library.splib
+            ${splib_file.extra_files_path}/library.splib
         #end for
 
-
         --replicates $replicates
-
         -o library;
 
         mkdir -p ${output.extra_files_path};
-
         cp library.splib library.spidx library.pepidx  ${output.extra_files_path}/;
 
-
         echo "Spectral Library Primary File" > $output
-
-	</command>
-
-	<inputs>
-
+    </command>
+    <inputs>
         <param name="splib_files" multiple="true" type="data" format="splib" label="Spectral Libraries to operate on" help=""/>
-	
         <param name="merge" type="select" format="text">
             <label>Merge Method</label>
             <option value="U">Union</option>
@@ -49,13 +39,10 @@
             <option value="C">Consensus</option>
             <option value="B">Best replicate</option>
         </param>
-
-	
     </inputs>
-
-      <outputs>
+    <outputs>
         <data format="splib" name="output"/>
-      </outputs>
+    </outputs>
     <help>
         Filter and Manipulate Spectral Libraries
     </help>

--- a/spectrast/spectrast_filter.xml
+++ b/spectrast/spectrast_filter.xml
@@ -9,6 +9,7 @@
         <exit_code range="1:" level="fatal" description="Job Failed" />
     </stdio>
     <command>
+<![CDATA[
         spectrast_filter.rb  --merge $merge
 
         #for $splib_file in $splib_files:
@@ -16,12 +17,20 @@
         #end for
 
         --replicates $replicates
-        -o library;
+        -o library
 
-        mkdir -p ${output.files_path};
-        cp library.splib library.spidx library.pepidx  ${output.files_path}/;
+        &&
+
+        mkdir -p ${output.files_path}
+
+        &&
+
+        cp library.splib library.spidx library.pepidx  ${output.files_path}/
+
+        &&
 
         echo "Spectral Library Primary File" > $output
+]]>
     </command>
     <inputs>
         <param name="splib_files" multiple="true" type="data" format="splib" label="Spectral Libraries to operate on" help=""/>

--- a/spectrast/spectrast_filter.xml
+++ b/spectrast/spectrast_filter.xml
@@ -44,6 +44,11 @@
         <data format="splib" name="output"/>
     </outputs>
     <help>
-        Filter and Manipulate Spectral Libraries
+<![CDATA[
+**What it does**
+
+Filter and Manipulate Spectral Libraries
+
+]]>
     </help>
 </tool>

--- a/spectrast/spectrast_filter.xml
+++ b/spectrast/spectrast_filter.xml
@@ -2,7 +2,7 @@
     <description>Filter and Manipulate Spectral Libraries</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.2</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4.2">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
     </requirements>
     <stdio>

--- a/spectrast/tool_dependencies.xml
+++ b/spectrast/tool_dependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="protk" version="1.4.2">
+        <repository name="package_protk_1_4_2" owner="iuc"/>
+    </package>
+</tool_dependency>

--- a/tpp-prophets/interprophet.xml
+++ b/tpp-prophets/interprophet.xml
@@ -8,18 +8,18 @@
     <command>
         interprophet.rb --galaxy
 
-        -o interprophet_output.pep.xml
-        $use_nss
-        $use_nrs
-        $use_nse
-        $use_nsi
-        $use_nsm
-        --p-thresh $p_thresh
-        --threads $threads
+            -o interprophet_output.pep.xml
+            $use_nss
+            $use_nrs
+            $use_nse
+            $use_nsi
+            $use_nsm
+            --p-thresh $p_thresh
+            --threads "\${GALAXY_SLOTS:-1}"
 
-        #for $pepxml_file in $pepxml_files:
-            ${pepxml_file}
-        #end for
+            #for $pepxml_file in $pepxml_files:
+                ${pepxml_file}
+            #end for
 
     </command>
     <inputs>
@@ -32,8 +32,6 @@
         <param name="use_nsi" checked="true" type="boolean" label="Include NSI in Model" help="Include NSI (Number of Sibling Ions) in Statistical Model" truevalue="" falsevalue="--no-nsi"/>
         <param name="use_nsm" checked="true" type="boolean" label="Include NSM in Model" help="Include NSM (Number of Sibling Modifications) in Statistical Model" truevalue="" falsevalue="--no-nsm"/>
         <param name="p_thresh" help="Peptides scoring less than this value are discarded" type="float" value="0.05" min="0" max="1" label="Probability Threshold"/>
-
-        <param name="threads" type="integer" value="1" min="0" label="Threads" help="Number of threads to use"/>
 
     </inputs>
     <outputs>

--- a/tpp-prophets/interprophet.xml
+++ b/tpp-prophets/interprophet.xml
@@ -2,7 +2,7 @@
     <description>Combine Peptide Prophet results from multiple search engines</description>
     <requirements>
          <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4.2">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
     </requirements>
     <command>

--- a/tpp-prophets/interprophet.xml
+++ b/tpp-prophets/interprophet.xml
@@ -1,5 +1,5 @@
 <tool id="proteomics_search_interprophet_1" name="InterProphet" version="1.1.0">
-	
+    <description>Combine Peptide Prophet results from multiple search engines</description>
 	<requirements>
          <container type="docker">iracooke/protk-1.4.1</container>
 	    <requirement type="package" version="1.4">protk</requirement>
@@ -7,9 +7,7 @@
    </requirements>
 
 
-  <description>Combine Peptide Prophet results from multiple search engines</description>
-
-  <command>interprophet.rb --galaxy
+    <command>interprophet.rb --galaxy
 
 	-o interprophet_output.pep.xml
 

--- a/tpp-prophets/interprophet.xml
+++ b/tpp-prophets/interprophet.xml
@@ -1,57 +1,45 @@
 <tool id="proteomics_search_interprophet_1" name="InterProphet" version="1.1.0">
     <description>Combine Peptide Prophet results from multiple search engines</description>
-	<requirements>
+    <requirements>
          <container type="docker">iracooke/protk-1.4.1</container>
-	    <requirement type="package" version="1.4">protk</requirement>
-	    <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
-   </requirements>
+        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
+    </requirements>
+    <command>
+        interprophet.rb --galaxy
 
+        -o interprophet_output.pep.xml
+        $use_nss
+        $use_nrs
+        $use_nse
+        $use_nsi
+        $use_nsm
+        --p-thresh $p_thresh
+        --threads $threads
 
-    <command>interprophet.rb --galaxy
+        #for $pepxml_file in $pepxml_files:
+            ${pepxml_file}
+        #end for
 
-	-o interprophet_output.pep.xml
+    </command>
+    <inputs>
 
-	$use_nss 
+        <param name="pepxml_files" multiple="true" type="data" format="peptideprophet_pepxml" label="Peptide Prophet Results" help="These files will typically be outputs from search tools that have subsequently been run through peptide prophet"/>
 
-	$use_nrs 
+        <param name="use_nss" checked="true" type="boolean" label="Include NSS in Model" help="Include NSS (Number of Sibling Searches) in Statistical Model" truevalue="" falsevalue="--no-nss"/>
+        <param name="use_nrs" checked="true" type="boolean" label="Include NRS in Model" help="Include NRS (Number of Replicate Spectra) in Statistical Model" truevalue="" falsevalue="--no-nrs"/>
+        <param name="use_nse" checked="true" type="boolean" label="Include NSE in Model" help="Include NSE (Number of Sibling Experiments) in Statistical Model" truevalue="" falsevalue="--no-nse"/>
+        <param name="use_nsi" checked="true" type="boolean" label="Include NSI in Model" help="Include NSI (Number of Sibling Ions) in Statistical Model" truevalue="" falsevalue="--no-nsi"/>
+        <param name="use_nsm" checked="true" type="boolean" label="Include NSM in Model" help="Include NSM (Number of Sibling Modifications) in Statistical Model" truevalue="" falsevalue="--no-nsm"/>
+        <param name="p_thresh" help="Peptides scoring less than this value are discarded" type="float" value="0.05" min="0" max="1" label="Probability Threshold"/>
 
-	$use_nse 
+        <param name="threads" type="integer" value="1" min="0" label="Threads" help="Number of threads to use"/>
 
-	$use_nsi 
-
-	$use_nsm 
-
-	--p-thresh $p_thresh
-
-	--threads $threads
-
-#for $pepxml_file in $pepxml_files:
-	${pepxml_file}
-#end for	
-
-  </command>
-
-
-  <inputs>
-
-	<param name="pepxml_files" multiple="true" type="data" format="peptideprophet_pepxml" label="Peptide Prophet Results" help="These files will typically be outputs from search tools that have subsequently been run through peptide prophet"/>
-
-	<param name="use_nss" checked="true" type="boolean" label="Include NSS in Model" help="Include NSS (Number of Sibling Searches) in Statistical Model" truevalue="" falsevalue="--no-nss"/>
-	<param name="use_nrs" checked="true" type="boolean" label="Include NRS in Model" help="Include NRS (Number of Replicate Spectra) in Statistical Model" truevalue="" falsevalue="--no-nrs"/>
-	<param name="use_nse" checked="true" type="boolean" label="Include NSE in Model" help="Include NSE (Number of Sibling Experiments) in Statistical Model" truevalue="" falsevalue="--no-nse"/>
-	<param name="use_nsi" checked="true" type="boolean" label="Include NSI in Model" help="Include NSI (Number of Sibling Ions) in Statistical Model" truevalue="" falsevalue="--no-nsi"/>
-	<param name="use_nsm" checked="true" type="boolean" label="Include NSM in Model" help="Include NSM (Number of Sibling Modifications) in Statistical Model" truevalue="" falsevalue="--no-nsm"/>
-	
-    <param name="p_thresh" help="Peptides scoring less than this value are discarded" type="float" value="0.05" min="0" max="1" label="Probability Threshold"/>
-
-	<param name="threads" type="integer" value="1" min="0" label="Threads" help="Number of threads to use"/>
-		
-  </inputs>
-  <outputs>
-    <data format="interprophet_pepxml" name="output" from_work_dir="interprophet_output.pep.xml"/>
-  </outputs>
-
- <help>
+    </inputs>
+    <outputs>
+        <data format="interprophet_pepxml" name="output" from_work_dir="interprophet_output.pep.xml"/>
+    </outputs>
+    <help>
 
 **What it does**
 
@@ -65,6 +53,5 @@ If you use this tool please read and cite the paper describing iProphet
 
 Shteynberg D, et al. “iProphet: Improved statistical validation of peptide identifications in shotgun proteomics.” *Molecular and Cellular Proteomics* 10, M111.007690 (2011).
 
-  </help>
-
+    </help>
 </tool>

--- a/tpp-prophets/peptide_prophet.xml
+++ b/tpp-prophets/peptide_prophet.xml
@@ -1,13 +1,12 @@
 <tool id="proteomics_search_peptide_prophet_1" name="Peptide Prophet" version="1.1.0">
+	<description>Calculate Peptide Prophet statistics on search results</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.1</container>
         <requirement type="package" version="1.4">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
    </requirements>
-   
-	<description>Calculate Peptide Prophet statistics on search results</description>
 
-	<command>
+    <command>
         peptide_prophet.rb --galaxy $input_file -o peptide_prophet_output.pep.xml
 
         -r 

--- a/tpp-prophets/peptide_prophet.xml
+++ b/tpp-prophets/peptide_prophet.xml
@@ -1,72 +1,66 @@
 <tool id="proteomics_search_peptide_prophet_1" name="Peptide Prophet" version="1.1.0">
-	<description>Calculate Peptide Prophet statistics on search results</description>
+    <description>Calculate Peptide Prophet statistics on search results</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.1</container>
         <requirement type="package" version="1.4">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
-   </requirements>
-
+    </requirements>
     <command>
-        peptide_prophet.rb --galaxy $input_file -o peptide_prophet_output.pep.xml
+        peptide_prophet.rb
+            --galaxy $input_file
+            -o peptide_prophet_output.pep.xml
+            -r 
+            $glyco 
+            $useicat 
+            $phospho 
+            $usepi
+            $usert
+            $accurate_mass
+            $no_ntt
+            $no_nmc
+            $use_gamma
+            $use_only_expect
+            $force_fit
+            $allow_alt_instruments
+            $maldi
+            $usedecoys
+            --decoy-prefix $decoy_prefix_string
 
-        -r 
-        $glyco 
-        $useicat 
-        $phospho 
-        $usepi 
-        $usert 
-        $accurate_mass 
-        $no_ntt 
-        $no_nmc 
-        $use_gamma 
-        $use_only_expect 
-        $force_fit 
-        $allow_alt_instruments 
-        $maldi
-        $usedecoys
-        --decoy-prefix $decoy_prefix_string
+            #if $experiment_label
+                --experiment-label $experiment_label
+            #end if
 
-#if $experiment_label
-        --experiment-label $experiment_label
-#end if
+            --p-thresh $p_thresh
+            --threads $threads
 
-        --p-thresh $p_thresh
+    </command>
+    <inputs>
+        <param name="input_file" type="data" format="raw_pepxml" multiple="false" label="Raw Search Results" help="These files will typically be outputs from omssa or xtandem search tools"/>
 
-        --threads $threads
-
-	</command>
-
-	<inputs>
-	
-    <param name="input_file" type="data" format="raw_pepxml" multiple="false" label="Raw Search Results" help="These files will typically be outputs from omssa or xtandem search tools"/>
-
-	<param name="glyco" type="boolean" label="Expect true positives to have a glycocapture motif" truevalue="--glyco" falsevalue=""/>
-	<param name="useicat" type="boolean" label="Use icat information" truevalue="--useicat" falsevalue=""/>
-	<param name="phospho" type="boolean" label="Use phospho information" truevalue="--phospho" falsevalue=""/>
-	<param name="usepi" type="boolean" label="Use pI information" truevalue="--usepi" falsevalue=""/>
-	<param name="usert" type="boolean" label="Use hydrophobicity / RT information" truevalue="--usert" falsevalue=""/>
-	<param name="accurate_mass" type="boolean" label="Use accurate mass binning" truevalue="--accurate-mass" falsevalue=""/>
-	<param name="no_ntt" type="boolean" label="Don't use NTT model" truevalue="--no-ntt" falsevalue=""/>
-	<param name="no_nmc" type="boolean" label="Don't use NMC model" truevalue="--no-nmc" falsevalue=""/>
-	<param name="use_gamma" type="boolean" label="Use Gamma distribution to model the negatives" help="Applies only to X!Tandem results" truevalue="--usegamma" falsevalue=""/>
-	<param name="use_only_expect" type="boolean" label="Only use Expect Score as the discriminant" help="Applies only to X!Tandem results. 
-        Helpful for data with homologous top hits e.g. phospho or glyco" truevalue="--use-only-expect" falsevalue=""/>
-	<param name="force_fit" type="boolean" label="Force fitting" help="Bypasses automatic mixture model checks and forces fitting of a mixture model" truevalue="--force-fit" falsevalue=""/>
-	<param name="allow_alt_instruments" type="boolean" label="Allow multiple instrument types" help="Warning instead of exit with error if instrument types between runs is different" truevalue="--allow-alt-instruments" falsevalue=""/>
-	<param name="maldi" type="boolean" label="Maldi data" truevalue="-l" falsevalue=""/>
-    <param name="usedecoys" type="boolean" label="Use decoys to pin down the negative distribution" truevalue="" falsevalue="--no-decoy"/>
-    <param name="decoy_prefix_string" help="Prefix string for decoy ids" type="text" value="decoy_" label="Decoy Prefix String" size="20"/>	
-    <param name="experiment_label" help="Used to commonly label all spectra from one experiment" type="text" value="" label="Experiment Label" size="20"/>
-    <param name="p_thresh" help="Peptides scoring less than this value are discarded" type="float" value="0.05" min="0" max="1" label="Probability Threshold"/>
-    <param name="threads" type="integer" value="1" min="0" label="Threads" help="Number of threads to use"/>
-	
-  </inputs>
-  <outputs>
-    <data format="peptideprophet_pepxml" name="output" metadata_source="input_file" label="peptide_prophet.${input_file.display_name}.pep.xml" from_work_dir="peptide_prophet_output.pep.xml"/>
-  </outputs>
-
-
-<help>
+        <param name="glyco" type="boolean" label="Expect true positives to have a glycocapture motif" truevalue="--glyco" falsevalue=""/>
+        <param name="useicat" type="boolean" label="Use icat information" truevalue="--useicat" falsevalue=""/>
+        <param name="phospho" type="boolean" label="Use phospho information" truevalue="--phospho" falsevalue=""/>
+        <param name="usepi" type="boolean" label="Use pI information" truevalue="--usepi" falsevalue=""/>
+        <param name="usert" type="boolean" label="Use hydrophobicity / RT information" truevalue="--usert" falsevalue=""/>
+        <param name="accurate_mass" type="boolean" label="Use accurate mass binning" truevalue="--accurate-mass" falsevalue=""/>
+        <param name="no_ntt" type="boolean" label="Don't use NTT model" truevalue="--no-ntt" falsevalue=""/>
+        <param name="no_nmc" type="boolean" label="Don't use NMC model" truevalue="--no-nmc" falsevalue=""/>
+        <param name="use_gamma" type="boolean" label="Use Gamma distribution to model the negatives" help="Applies only to X!Tandem results" truevalue="--usegamma" falsevalue=""/>
+        <param name="use_only_expect" type="boolean" label="Only use Expect Score as the discriminant" help="Applies only to X!Tandem results. 
+            Helpful for data with homologous top hits e.g. phospho or glyco" truevalue="--use-only-expect" falsevalue=""/>
+        <param name="force_fit" type="boolean" label="Force fitting" help="Bypasses automatic mixture model checks and forces fitting of a mixture model" truevalue="--force-fit" falsevalue=""/>
+        <param name="allow_alt_instruments" type="boolean" label="Allow multiple instrument types" help="Warning instead of exit with error if instrument types between runs is different" truevalue="--allow-alt-instruments" falsevalue=""/>
+        <param name="maldi" type="boolean" label="Maldi data" truevalue="-l" falsevalue=""/>
+        <param name="usedecoys" type="boolean" label="Use decoys to pin down the negative distribution" truevalue="" falsevalue="--no-decoy"/>
+        <param name="decoy_prefix_string" help="Prefix string for decoy ids" type="text" value="decoy_" label="Decoy Prefix String" size="20"/>    
+        <param name="experiment_label" help="Used to commonly label all spectra from one experiment" type="text" value="" label="Experiment Label" size="20"/>
+        <param name="p_thresh" help="Peptides scoring less than this value are discarded" type="float" value="0.05" min="0" max="1" label="Probability Threshold"/>
+        <param name="threads" type="integer" value="1" min="0" label="Threads" help="Number of threads to use"/>
+    </inputs>
+    <outputs>
+        <data format="peptideprophet_pepxml" name="output" metadata_source="input_file" label="peptide_prophet.${input_file.display_name}.pep.xml" from_work_dir="peptide_prophet_output.pep.xml"/>
+    </outputs>
+    <help>
 
 **What it does**
 
@@ -81,7 +75,7 @@ If you use this tool please read and cite the paper describing the statistical m
 Keller A., et al. “Empirical Statistical Model to Estimate the Accuracy of Peptide Identifications Made by MS/MS and Database Search” *Anal. Chem.* 74, 5383-5392 (2002).
 
 
-</help>
+    </help>
 
 
 <!--PeptideProphet options [following the 'O']:

--- a/tpp-prophets/peptide_prophet.xml
+++ b/tpp-prophets/peptide_prophet.xml
@@ -2,7 +2,7 @@
     <description>Calculate Peptide Prophet statistics on search results</description>
     <requirements>
         <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4.2">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
     </requirements>
     <command>

--- a/tpp-prophets/peptide_prophet.xml
+++ b/tpp-prophets/peptide_prophet.xml
@@ -31,7 +31,8 @@
             #end if
 
             --p-thresh $p_thresh
-            --threads $threads
+            --threads "\${GALAXY_SLOTS:-1}"
+
 
     </command>
     <inputs>
@@ -55,7 +56,6 @@
         <param name="decoy_prefix_string" help="Prefix string for decoy ids" type="text" value="decoy_" label="Decoy Prefix String" size="20"/>    
         <param name="experiment_label" help="Used to commonly label all spectra from one experiment" type="text" value="" label="Experiment Label" size="20"/>
         <param name="p_thresh" help="Peptides scoring less than this value are discarded" type="float" value="0.05" min="0" max="1" label="Probability Threshold"/>
-        <param name="threads" type="integer" value="1" min="0" label="Threads" help="Number of threads to use"/>
     </inputs>
     <outputs>
         <data format="peptideprophet_pepxml" name="output" metadata_source="input_file" label="peptide_prophet.${input_file.display_name}.pep.xml" from_work_dir="peptide_prophet_output.pep.xml"/>

--- a/tpp-prophets/pepxml_to_table.xml
+++ b/tpp-prophets/pepxml_to_table.xml
@@ -1,13 +1,10 @@
 <tool id="pepxml_to_table_1" name="PepXML to Table" version="1.1.0">
-
+    <description>Converts a pepXML file to a tab delimited text file</description>
 	<requirements>
             <container type="docker">iracooke/protk-1.4.1</container>
 	    <requirement type="package" version="1.4">protk</requirement>
    </requirements>
 
-
-
-  <description>Converts a pepXML file to a tab delimited text file</description>
 
 
 <!-- Note .. the input file is assumed to be the first argument -->

--- a/tpp-prophets/pepxml_to_table.xml
+++ b/tpp-prophets/pepxml_to_table.xml
@@ -1,8 +1,8 @@
 <tool id="pepxml_to_table_1" name="PepXML to Table" version="1.1.0">
     <description>Converts a pepXML file to a tab delimited text file</description>
     <requirements>
-            <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <container type="docker">iracooke/protk-1.4.1</container>
+        <requirement type="package" version="1.4.2">protk</requirement>
     </requirements>
     <!-- Note .. the input file is assumed to be the first argument -->
     <command>pepxml_to_table.rb $input_file -o $output $invert_probs</command>

--- a/tpp-prophets/pepxml_to_table.xml
+++ b/tpp-prophets/pepxml_to_table.xml
@@ -1,42 +1,30 @@
 <tool id="pepxml_to_table_1" name="PepXML to Table" version="1.1.0">
     <description>Converts a pepXML file to a tab delimited text file</description>
-	<requirements>
+    <requirements>
             <container type="docker">iracooke/protk-1.4.1</container>
-	    <requirement type="package" version="1.4">protk</requirement>
-   </requirements>
-
-
-
-<!-- Note .. the input file is assumed to be the first argument -->
-<command>pepxml_to_table.rb $input_file -o $output $invert_probs</command>
-
-
-<inputs>
-
-	<param name="input_file" type="data" format="pepxml,raw_pepxml,peptideprophet_pepxml,interprophet_pepxml"  multiple="false" label="Input File" help="A pepXML file"/>
-    <param name="invert_probs" type="boolean" label="Print inverted probabilities (ie 1-p instead of p)" truevalue="--invert-probabilities" falsevalue=""/>
-
-</inputs>
-<outputs>
-	<data format="csv" name="output" metadata_source="input_file" label="${input_file.display_name}.csv" />
-</outputs>
-
-	
-	<tests>
-	  <!-- Just test that the tool runs and produces vaguely correct output -->
-	  <test>
-	      <param name="input_file" value="mr176-BSA100fmole_BA3_01_8168.d_tandem.pep.xml" format="raw_pepxml"/>
-	      <output name="output" format="csv">
-	          <assert_contents>
-	              <has_text text="ANTNNYAPKSSR" />
-	          </assert_contents>
-	      </output>
-	  </test>
-	</tests>
-
-
+        <requirement type="package" version="1.4">protk</requirement>
+    </requirements>
+    <!-- Note .. the input file is assumed to be the first argument -->
+    <command>pepxml_to_table.rb $input_file -o $output $invert_probs</command>
+    <inputs>
+        <param name="input_file" type="data" format="pepxml,raw_pepxml,peptideprophet_pepxml,interprophet_pepxml"  multiple="false" label="Input File" help="A pepXML file"/>
+        <param name="invert_probs" type="boolean" label="Print inverted probabilities (ie 1-p instead of p)" truevalue="--invert-probabilities" falsevalue=""/>
+    </inputs>
+    <outputs>
+        <data format="csv" name="output" metadata_source="input_file" label="${input_file.display_name}.csv" />
+    </outputs>
+    <tests>
+        <!-- Just test that the tool runs and produces vaguely correct output -->
+        <test>
+            <param name="input_file" value="mr176-BSA100fmole_BA3_01_8168.d_tandem.pep.xml" format="raw_pepxml"/>
+            <output name="output" format="csv">
+                <assert_contents>
+                    <has_text text="ANTNNYAPKSSR" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 <help>
-	Convert a pepXML file to Tab delimited text
+    Convert a pepXML file to Tab delimited text
 </help>
-
 </tool>

--- a/tpp-prophets/protein_prophet.xml
+++ b/tpp-prophets/protein_prophet.xml
@@ -2,76 +2,68 @@
     <description>Calculate Protein Prophet statistics on search results</description>
     <requirements>
             <container type="docker">iracooke/protk-1.4.1</container>
-	    <requirement type="package" version="1.4">protk</requirement>
-	    <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
-   </requirements>
+        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
+    </requirements>
 
-<!-- Note .. the input file is assumed to be the first argument -->
-  <command>
-  	protein_prophet.rb
+    <!-- Note .. the input file is assumed to be the first argument -->
+    <command>
+        protein_prophet.rb
+            --galaxy $input_file
+            -o protein_prophet_results.prot.xml
+            -r
 
-  	--galaxy $input_file 
+            $iproph
+            $nooccam
+            $groupwts
+            $normprotlen
+            $logprobs
+            $confem
+            $allpeps
+            $unmapped
+            $instances
+            $delude
+          --minprob=$minprob
+          --minindep=$minindep
+    </command>
+    <inputs>
+        <param name="input_file" type="data" format="peptideprophet_pepxml,interprophet_pepxml" multiple="false" label="Peptide Prophet Results" help="These files will typically be outputs from peptide prophet or interprophet"/>
 
-  	-o protein_prophet_results.prot.xml
+        <param name="iproph" selected="true" type="boolean" label="Inputs are from iProphet" truevalue="--iprophet-input" falsevalue=""/>
+        <param name="nooccam" type="boolean" label="Don't apply Occam's razor" help="When selected no attempt will be made to derive the simplest protein list explaining observed peptides" truevalue="--no-occam" falsevalue=""/>
+        <param name="groupwts" type="boolean" label="Use group weights" help="Check peptide's total weight (rather than actual weight) in the Protein Group against the threshold" truevalue="--group-wts" falsevalue=""/>
+        <param name="normprotlen" type="boolean" label="Normalize NSP using Protein Length" truevalue="--norm-protlen" falsevalue=""/>
+        <param name="logprobs" type="boolean" label="Use the log of probability in the confidence calculations" truevalue="--log-prob" falsevalue=""/>
+        <param name="confem" type="boolean" label="Use the EM to compute probability given the confidenct" truevalue="--confem" falsevalue=""/>
+        <param name="allpeps" type="boolean" label="Consider all possible peptides in the database in the confidence model" truevalue="--allpeps" falsevalue=""/>
+        <param name="unmapped" type="boolean" label="Report results for unmapped proteins" truevalue="--unmapped" falsevalue=""/>
+        <param name="instances" type="boolean" label="Use Expected Number of Ion Instances to adjust the peptide probabilities prior to NSP adjustment" truevalue="--instances" falsevalue=""/>
+        <param name="delude" type="boolean" label="Do NOT use peptide degeneracy information when assessing proteins" truevalue="--delude" falsevalue=""/>
 
-  	-r
-
-  	$iproph 
-  	$nooccam 
-  	$groupwts 
-  	$normprotlen 
-  	$logprobs 
-  	$confem 
-  	$allpeps 
-  	$unmapped 
-  	$instances 
-  	$delude
-  	
-  	--minprob=$minprob 
-  	--minindep=$minindep 
-  </command>
-  <inputs>
-	
-    <param name="input_file" type="data" format="peptideprophet_pepxml,interprophet_pepxml" multiple="false" label="Peptide Prophet Results" help="These files will typically be outputs from peptide prophet or interprophet"/>
-
-	<param name="iproph" selected="true" type="boolean" label="Inputs are from iProphet" truevalue="--iprophet-input" falsevalue=""/>
-	<param name="nooccam" type="boolean" label="Don't apply Occam's razor" help="When selected no attempt will be made to derive the simplest protein list explaining observed peptides" truevalue="--no-occam" falsevalue=""/>
-	<param name="groupwts" type="boolean" label="Use group weights" help="Check peptide's total weight (rather than actual weight) in the Protein Group against the threshold" truevalue="--group-wts" falsevalue=""/>
-	<param name="normprotlen" type="boolean" label="Normalize NSP using Protein Length" truevalue="--norm-protlen" falsevalue=""/>
-	<param name="logprobs" type="boolean" label="Use the log of probability in the confidence calculations" truevalue="--log-prob" falsevalue=""/>
-	<param name="confem" type="boolean" label="Use the EM to compute probability given the confidenct" truevalue="--confem" falsevalue=""/>
-	<param name="allpeps" type="boolean" label="Consider all possible peptides in the database in the confidence model" truevalue="--allpeps" falsevalue=""/>
-	<param name="unmapped" type="boolean" label="Report results for unmapped proteins" truevalue="--unmapped" falsevalue=""/>
-	<param name="instances" type="boolean" label="Use Expected Number of Ion Instances to adjust the peptide probabilities prior to NSP adjustment" truevalue="--instances" falsevalue=""/>
-	<param name="delude" type="boolean" label="Do NOT use peptide degeneracy information when assessing proteins" truevalue="--delude" falsevalue=""/>
-
-	<param name="minprob" type="text" label="Minimum peptide prophet probability for peptides to be considered" value="0.05"/>
-	<param name="minindep" type="text" label="Minimum percentage of independent peptides required for a protein" value="0"/>
-	
-  </inputs>
-  <outputs>
-    <data format="protxml" name="output" metadata_source="input_file" label="protein_prophet.${input_file.display_name}.protXML" from_work_dir="protein_prophet_results.prot.xml"/>
-  </outputs>
+        <param name="minprob" type="text" label="Minimum peptide prophet probability for peptides to be considered" value="0.05"/>
+        <param name="minindep" type="text" label="Minimum percentage of independent peptides required for a protein" value="0"/>
+    </inputs>
+    <outputs>
+        <data format="protxml" name="output" metadata_source="input_file" label="protein_prophet.${input_file.display_name}.protXML" from_work_dir="protein_prophet_results.prot.xml"/>
+    </outputs>
 
 
 <!--NOPLOT: do not generate plot png file
-		NOOCCAM: non-conservative maximum protein list
-		GROUPWTS: check peptide's total weight in the Protein Group against the threshold (default: check peptide's actual weight against threshold)   
-		NORMPROTLEN: Normalize NSP using Protein Length
-		LOGPROBS: Use the log of the probabilities in the Confidence calculations
-		CONFEM: Use the EM to compute probability given the confidence 
-		ALLPEPS: Consider all possible peptides in the database in the confidence model
-		UNMAPPED: Report results for UNMAPPED proteins
-		INSTANCES: Use Expected Number of Ion Instances to adjust the peptide probabilities prior to NSP adjustment
-		DELUDE: do NOT use peptide degeneracy information when assessing proteins
-		
-		MINPROB: peptideProphet probabilty threshold (default=0.05) 
-		MININDEP: minimum percentage of independent peptides required for a protein (default=0) 
-		
-		
+        NOOCCAM: non-conservative maximum protein list
+        GROUPWTS: check peptide's total weight in the Protein Group against the threshold (default: check peptide's actual weight against threshold)   
+        NORMPROTLEN: Normalize NSP using Protein Length
+        LOGPROBS: Use the log of the probabilities in the Confidence calculations
+        CONFEM: Use the EM to compute probability given the confidence 
+        ALLPEPS: Consider all possible peptides in the database in the confidence model
+        UNMAPPED: Report results for UNMAPPED proteins
+        INSTANCES: Use Expected Number of Ion Instances to adjust the peptide probabilities prior to NSP adjustment
+        DELUDE: do NOT use peptide degeneracy information when assessing proteins
+        
+        MINPROB: peptideProphet probabilty threshold (default=0.05) 
+        MININDEP: minimum percentage of independent peptides required for a protein (default=0) 
 -->
 
-  <help>
+    <help>
 
 **What it does**
 
@@ -86,6 +78,5 @@ If you use this tool please read and cite the paper describing the statistical m
 Nesvizhskii A., et al. “A Statistical Model for Identifying Proteins by Tandem Mass Spectrometry” *Anal. Chem.* 75, 4646-4658 (2003).
 
 
-  </help>
-
+    </help>
 </tool>

--- a/tpp-prophets/protein_prophet.xml
+++ b/tpp-prophets/protein_prophet.xml
@@ -1,12 +1,10 @@
 <tool id="proteomics_search_protein_prophet_1" name="Protein Prophet" version="1.1.0">
-	<requirements>
+    <description>Calculate Protein Prophet statistics on search results</description>
+    <requirements>
             <container type="docker">iracooke/protk-1.4.1</container>
 	    <requirement type="package" version="1.4">protk</requirement>
 	    <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
    </requirements>
-
-  <description>Calculate Protein Prophet statistics on search results</description>
-
 
 <!-- Note .. the input file is assumed to be the first argument -->
   <command>

--- a/tpp-prophets/protein_prophet.xml
+++ b/tpp-prophets/protein_prophet.xml
@@ -1,8 +1,8 @@
 <tool id="proteomics_search_protein_prophet_1" name="Protein Prophet" version="1.1.0">
     <description>Calculate Protein Prophet statistics on search results</description>
     <requirements>
-            <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <container type="docker">iracooke/protk-1.4.1</container>
+        <requirement type="package" version="1.4.2">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
     </requirements>
 

--- a/tpp-prophets/protxml_to_table.xml
+++ b/tpp-prophets/protxml_to_table.xml
@@ -1,15 +1,14 @@
 <tool id="protxml_to_table_1" name="ProtXML to Table" version="1.1.0">
     <description>Converts a ProtXML file to a table</description>
     <requirements>
-            <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <container type="docker">iracooke/protk-1.4.1</container>
+        <requirement type="package" version="1.4.2">protk</requirement>
     </requirements>
     <command>
-        protxml_to_table.rb 
+        protxml_to_table.rb
           $invert_probs
-
-        $input_file 
-        -o $output 
+        $input_file
+        -o $output
     </command>
     <inputs>
         <param format="protxml" name="input_file" type="data" label="ProtXML File to Convert"/>

--- a/tpp-prophets/protxml_to_table.xml
+++ b/tpp-prophets/protxml_to_table.xml
@@ -1,10 +1,11 @@
 <tool id="protxml_to_table_1" name="ProtXML to Table" version="1.1.0">
-	<requirements>
+    <description>Converts a ProtXML file to a table</description>
+    <requirements>
             <container type="docker">iracooke/protk-1.4.1</container>
 	    <requirement type="package" version="1.4">protk</requirement>
    </requirements>
 
-	<description>Converts a ProtXML file to a table</description>
+
 
 	<command>
 		protxml_to_table.rb 

--- a/tpp-prophets/protxml_to_table.xml
+++ b/tpp-prophets/protxml_to_table.xml
@@ -2,49 +2,37 @@
     <description>Converts a ProtXML file to a table</description>
     <requirements>
             <container type="docker">iracooke/protk-1.4.1</container>
-	    <requirement type="package" version="1.4">protk</requirement>
-   </requirements>
+        <requirement type="package" version="1.4">protk</requirement>
+    </requirements>
+    <command>
+        protxml_to_table.rb 
+          $invert_probs
 
-
-
-	<command>
-		protxml_to_table.rb 
-	  	$invert_probs
-
-		$input_file 
-		-o $output 
-	</command>
-
-	<inputs>	
-		
-		<param format="protxml" name="input_file" type="data" label="ProtXML File to Convert"/>
-	    <param name="invert_probs" type="boolean" label="Print inverted probabilities (ie 1-p instead of p)" truevalue="--invert-probabilities" falsevalue=""/>
-	</inputs>
-
-
-	<outputs>
-		<data format="tabular" name="output" />
-	</outputs>
-
-	<tests>
-	  <!-- Just test that the tool runs and produces vaguely correct output -->
-	  <test>
-	      <param name="input_file" value="mr176-BSA100fmole_BA3_01_8168.d_tandem_pproph_protproph.prot.xml" format="protxml"/>
-	      <output name="output" format="tabular">
-	          <assert_contents>
-	              <has_text text="AVQKYLTAHEQSK" />
-	          </assert_contents>
-	      </output>
-	  </test>
-	</tests>
-
-
-  <help>
-
+        $input_file 
+        -o $output 
+    </command>
+    <inputs>
+        <param format="protxml" name="input_file" type="data" label="ProtXML File to Convert"/>
+        <param name="invert_probs" type="boolean" label="Print inverted probabilities (ie 1-p instead of p)" truevalue="--invert-probabilities" falsevalue=""/>
+    </inputs>
+    <outputs>
+        <data format="tabular" name="output" />
+    </outputs>
+    <tests>
+      <!-- Just test that the tool runs and produces vaguely correct output -->
+      <test>
+          <param name="input_file" value="mr176-BSA100fmole_BA3_01_8168.d_tandem_pproph_protproph.prot.xml" format="protxml"/>
+          <output name="output" format="tabular">
+              <assert_contents>
+                  <has_text text="AVQKYLTAHEQSK" />
+              </assert_contents>
+          </output>
+      </test>
+    </tests>
+    <help>
 **What it does**
 
 Converts a ProtXML file to a tab separated table 
 
-  </help>
-
+    </help>
 </tool>

--- a/tpp-prophets/tool_dependencies.xml
+++ b/tpp-prophets/tool_dependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="protk" version="1.4.2">
+        <repository name="package_protk_1_4_2" owner="iuc"/>
+    </package>
+</tool_dependency>

--- a/xtandem/tandem.xml
+++ b/xtandem/tandem.xml
@@ -1,12 +1,9 @@
 <tool id="proteomics_search_tandem_1" name="X!Tandem MSMS Search" version="1.1.0">
-
+    <description>Run an X!Tandem Search</description>
    <requirements>
          <container type="docker">iracooke/protk-1.4.1</container>
 	    <requirement type="package" version="1.4">protk</requirement>
    </requirements>
-
-	<description>Run an X!Tandem Search</description>
-
 	<command>
 		#if $database.source_select=="built_in":
 		tandem_search.rb -d $database.dbkey 

--- a/xtandem/tandem.xml
+++ b/xtandem/tandem.xml
@@ -2,8 +2,8 @@
     <description>Run an X!Tandem Search</description>
    <requirements>
          <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
-   </requirements>
+        <requirement type="package" version="1.4.2">protk</requirement>
+    </requirements>
     <command>
         #if $database.source_select=="built_in":
             tandem_search.rb -d $database.dbkey 

--- a/xtandem/tandem.xml
+++ b/xtandem/tandem.xml
@@ -44,7 +44,7 @@
         $acetyl_protein_nterm
         $cleavage_semi
         $keep_spectra
-        --threads $threads
+        --threads "\${GALAXY_SLOTS:-1}"
 
     </command>
     <inputs>
@@ -128,8 +128,6 @@
 
         <param name="keep_spectra" type="boolean" label="Keep Spectra" help="Include spectra in the output" truevalue="--output-spectra" falsevalue=""/>
 
-        <param name="threads" type="integer" value="1" label="Threads" help="Number of threads to use for search. Maximum is 16"/>
-        
         <param name="enzyme" type="select" format="text">
             <label>Enzyme</label>
             <option value="[R]__pc__{P}">argc - [R]|{P}</option>

--- a/xtandem/tandem.xml
+++ b/xtandem/tandem.xml
@@ -2,202 +2,186 @@
     <description>Run an X!Tandem Search</description>
    <requirements>
          <container type="docker">iracooke/protk-1.4.1</container>
-	    <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="1.4">protk</requirement>
    </requirements>
-	<command>
-		#if $database.source_select=="built_in":
-		tandem_search.rb -d $database.dbkey 
-		#else 
-		tandem_search.rb -d $database.fasta_file
-		#end if
+    <command>
+        #if $database.source_select=="built_in":
+            tandem_search.rb -d $database.dbkey 
+        #else
+            tandem_search.rb -d $database.fasta_file
+        #end if
 
-		#if $tandem_params.source_select=="built_in":
-		-T $tandem_params.paramskey 
-		#else 
-		-T $tandem_params.params_file
-		#end if
-
-
-		--var-mods='
-		$variable_mods
-		#for $custom_variable_mod in $custom_variable_mods:
-		,${custom_variable_mod.custom_mod}
-		#end for
-		'
-
-		--fix-mods='
-		$fixed_mods
-		#for $custom_fix_mod in $custom_fix_mods:
-		,${custom_fix_mod.custom_mod}
-		#end for
-		'
-
-		$input_file -o $output -r 
-
-		--enzyme=$enzyme 
-
-		--precursor-ion-tol-units=$precursor_tolu 
-
-		-v $missed_cleavages 
-
-		-f $fragment_ion_tol 
-
-		-p $precursor_ion_tol
-
-		$allow_multi_isotope_search 
-
-		$acetyl_protein_nterm
-
-		$cleavage_semi
-
-		$keep_spectra
-
-		--threads $threads
-		
-	</command>
-
-	<inputs>
-		<conditional name="database">
-			<param name="source_select" type="select" label="Database source">
-				<option value="built_in">Built-In</option>
-				<option value="input_ref" selected="true">Your Upload File</option>
-			</param>
-			<when value="built_in">
-				<param name="dbkey" type="select" format="text" >
-					<label>Database</label>
-					<options from_file="pepxml_databases.loc">
-						<column name="name" index="0" />
-						<column name="value" index="2" />
-					</options>
-				</param>
-			</when>
-			<when value="input_ref">
-				<param name="fasta_file" type="data" format="fasta" label="Uploaded FASTA file" />
-			</when>
-		</conditional>
-		
-		<conditional name="tandem_params">
-			<param name="source_select" type="select" label="Baseline Parameters">
-				<option value="built_in" selected="true">Built-In</option>
-				<option value="input_ref">Custom parameter file</option>
-			</param>
-			<when value="built_in">
-				<param name="paramskey" type="select" format="text" >
-					<label>Paramset</label>
-					<option value="isb_kscore">ISB K-Score (Recommended for TPP)</option>
-				    <option value="isb_native">ISB Native</option>		
-				    <option value="gpm">GPM</option>
-				</param>
-			</when>
-			<when value="input_ref">
-				<param name="params_file" type="data" format="xml" label="Custom X!Tandem Parameters" />
-			</when>
-		</conditional>
-
-		<param name="input_file" type="data" format="mzml,mgf" multiple="false" label="MSMS File" help="A file with MS/MS data"/>
-
-		<param name="variable_mods" format="text" type="select" multiple="true" label="Variable Modifications" help="Hold the appropriate key while
-			clicking to select multiple items">
-			<options from_file="tandem_mods.loc">
-				<column name="name" index="0" />
-				<column name="value" index="2" />
-			</options>
-		</param>
-
-		<repeat name="custom_variable_mods" title="Custom Variable Modifications" help="You can specify a modification when present in a motif. For instance, 0.998@N!{P}[ST] is a deamidation modification on N only if it is present in an N[any but P][S or T] motif (N-glycosite).">
-			<param name="custom_mod" type="text">
-			</param>
-		</repeat>
-		
-		
-		<param name="fixed_mods" format="text" type="select" multiple="true" label="Fixed Modifications" help="Hold the appropriate key while
-			clicking to select multiple items">
-			<options from_file="tandem_mods.loc">
-				<column name="name" index="0" />
-				<column name="value" index="2" />
-			</options>
-		</param>
-
-		<repeat name="custom_fix_mods" title="Custom Fixed Modifications" help="You can specify a modification when present in a motif. For instance, 0.998@N!{P}[ST] is a deamidation modification on N only if it is present in an N[any but P][S or T] motif (N-glycosite).">
-			<param name="custom_mod" type="text">
-			</param>
-		</repeat>
-
-		<param name="acetyl_protein_nterm" type="boolean" label="Allow N-terminal protein acetylation as a variable modification" truevalue="-y" falsevalue="" />		
-		
-
-		<param name="missed_cleavages" type="select" format="text" help="Allow peptides to contain up to this many missed enzyme cleavage sites">
-			<label>Missed Cleavages Allowed</label>
-		    <option value="0">0</option>		
-			<option value="1">1</option>
-			<option selected="true" value="2">2</option>
-		</param>
-
-		<param name="cleavage_semi" type="boolean" label="Allow semi-cleaved peptides" help="This can increase search time dramatically" truevalue="--cleavage-semi" falsevalue=""/>
-
-		<param name="keep_spectra" type="boolean" label="Keep Spectra" help="Include spectra in the output" truevalue="--output-spectra" falsevalue=""/>
-
-		<param name="threads" type="integer" value="1" label="Threads" help="Number of threads to use for search. Maximum is 16"/>
-		
-		<param name="enzyme" type="select" format="text">
-		    <label>Enzyme</label>
-			<option value="[R]__pc__{P}">argc - [R]|{P}</option>
-			<option value="[X]__pc__[D]">aspn - [X]|[D]</option>
-			<option value="[FLMWY]__pc__{P}">chymotrypsin - [FLMWY]|{P}</option>
-			<option value="[R]__pc__[X]">clostripain - [R]|[X]</option>
-			<option value="[M]__pc__{X}">cnbr - [M]|{X}</option>
-			<option value="[AGILV]__pc__{P}">elastase - [AGILV]|{P}</option>
-			<option value="[D]__pc__{P}">formicacid - [D]|{P}</option>
-			<option value="[DE]__pc__{P}">gluc - [DE]|{P}</option>
-			<option value="[E]__pc__{P}">gluc_bicarb - [E]|{P}</option>
-			<option value="[W]__pc__[X]">iodosobenzoate - [W]|[X]</option>
-			<option value="[K]__pc__{P}">lysc - [K]|{P}</option>
-			<option value="[K]__pc__[X]">lysc-p - [K]|[X]</option>
-			<option value="[X]__pc__[K]">lysn - [X]|[K]</option>
-			<option value="[X]__pc__[AKRS]">lysn_promisc - [X]|[AKRS]</option>
-			<option value="[X]__pc__[X]">nonspecific - [X]|[X]</option>
-			<option value="[FL]__pc__[X]">pepsina - [FL]|[X]</option>
-			<option value="[P]__pc__[X]">protein_endopeptidase - [P]|[X]</option>
-			<option value="[E]__pc__[X]">staph_protease - [E]|[X]</option>
-			<option value="[FMWY]__pc__{P},[KR]__pc__{P},[X]__pc__[D]">tca - [FMWY]|{P},[KR]|{P},[X]|[D]</option>
-			<option value="[KR]__pc__{P}" selected="true">trypsin - [KR]|{P}</option>
-			<option value="[FKLMRWY]__pc__{P}">trypsin/chymotrypsin - [FKLMRWY]|{P}</option>
-			<option value="[KR]__pc__{P},[M]__pc__{P}">trypsin/cnbr - [KR]|{P},[M]|{P}</option>
-			<option value="[DEKR]__pc__{P}">trypsin_gluc - [DEKR]|{P}</option>
-		</param>
-
-		
-		<param name="fragment_ion_tol" help="Fragment Ion Tolerance in Daltons" type="float" value="0.5" min="0" max="10000" label="Fragment ion tolerance"/>
-
-		<param name="precursor_ion_tol" help="Precursor Ion Tolerance (Da or ppm)" type="float" value="10" min="0" max="10000" label="Precursor ion tolerance"/>
-		<param name="precursor_tolu" type="select" format="text">
-		    <label>Precursor Ion Tolerance Units</label>
-		    <option value="ppm">ppm</option>		
-			<option value="Da">Da</option>
-		</param>
-		
-		<param name="allow_multi_isotope_search" type="boolean" label="Allow multi-isotope search" help="This allows peptide candidates in windows around -1 Da and -2 Da from the acquired mass to be considered. Only applicable when the minus/plus window above is set to less than 0.5 Da. Good for accurate-mass instruments for which the reported precursor mass is not corrected to the monoisotopic mass." truevalue="--multi-isotope-search" falsevalue=""/>
-
-	</inputs>
+        #if $tandem_params.source_select=="built_in":
+            -T $tandem_params.paramskey 
+        #else 
+            -T $tandem_params.params_file
+        #end if
 
 
-	<outputs>
-		<data format="tandem" name="output" metadata_source="input_file" label="X!Tandem_vs_${database.dbkey if $database.has_key('dbkey') else $database.fasta_file.display_name}.${input_file.display_name}.${input_file.display_name}.tandem"/>
-	</outputs>
+        --var-mods='
+        $variable_mods
+        #for $custom_variable_mod in $custom_variable_mods:
+            ,${custom_variable_mod.custom_mod}
+        #end for
+        '
 
-	<tests>
-		<!-- Just test that the tool runs and produces vaguely correct output -->
-		<test>
-		    <param name="source_select" value="input_ref"/>
-		    <param name="fasta_file" value="testdb.fasta" format="fasta"/>
-		    <param name="input_file" value="tiny.mzML" format="mzml"/>
-		    <output name="output" format="tandem">
-		        <assert_contents>
-					<has_text text="tandem-style" />
-		        </assert_contents>
-		    </output>
-		</test>
-	</tests>
+        --fix-mods='
+        $fixed_mods
+        #for $custom_fix_mod in $custom_fix_mods:
+            ,${custom_fix_mod.custom_mod}
+        #end for
+        '
+
+        $input_file -o $output -r 
+
+        --enzyme=$enzyme 
+
+        --precursor-ion-tol-units=$precursor_tolu 
+        -v $missed_cleavages 
+        -f $fragment_ion_tol 
+        -p $precursor_ion_tol
+        $allow_multi_isotope_search 
+        $acetyl_protein_nterm
+        $cleavage_semi
+        $keep_spectra
+        --threads $threads
+
+    </command>
+    <inputs>
+        <conditional name="database">
+            <param name="source_select" type="select" label="Database source">
+                <option value="built_in">Built-In</option>
+                <option value="input_ref" selected="true">Your Upload File</option>
+            </param>
+            <when value="built_in">
+                <param name="dbkey" type="select" format="text" >
+                    <label>Database</label>
+                    <options from_file="pepxml_databases.loc">
+                        <column name="name" index="0" />
+                        <column name="value" index="2" />
+                    </options>
+                </param>
+            </when>
+            <when value="input_ref">
+                <param name="fasta_file" type="data" format="fasta" label="Uploaded FASTA file" />
+            </when>
+        </conditional>
+        
+        <conditional name="tandem_params">
+            <param name="source_select" type="select" label="Baseline Parameters">
+                <option value="built_in" selected="true">Built-In</option>
+                <option value="input_ref">Custom parameter file</option>
+            </param>
+            <when value="built_in">
+                <param name="paramskey" type="select" format="text" >
+                    <label>Paramset</label>
+                    <option value="isb_kscore">ISB K-Score (Recommended for TPP)</option>
+                    <option value="isb_native">ISB Native</option>        
+                    <option value="gpm">GPM</option>
+                </param>
+            </when>
+            <when value="input_ref">
+                <param name="params_file" type="data" format="xml" label="Custom X!Tandem Parameters" />
+            </when>
+        </conditional>
+
+        <param name="input_file" type="data" format="mzml,mgf" multiple="false" label="MSMS File" help="A file with MS/MS data"/>
+
+        <param name="variable_mods" format="text" type="select" multiple="true" label="Variable Modifications" help="Hold the appropriate key while
+            clicking to select multiple items">
+            <options from_file="tandem_mods.loc">
+                <column name="name" index="0" />
+                <column name="value" index="2" />
+            </options>
+        </param>
+
+        <repeat name="custom_variable_mods" title="Custom Variable Modifications" help="You can specify a modification when present in a motif. For instance, 0.998@N!{P}[ST] is a deamidation modification on N only if it is present in an N[any but P][S or T] motif (N-glycosite).">
+            <param name="custom_mod" type="text">
+            </param>
+        </repeat>
+        
+        
+        <param name="fixed_mods" format="text" type="select" multiple="true" label="Fixed Modifications" help="Hold the appropriate key while
+            clicking to select multiple items">
+            <options from_file="tandem_mods.loc">
+                <column name="name" index="0" />
+                <column name="value" index="2" />
+            </options>
+        </param>
+
+        <repeat name="custom_fix_mods" title="Custom Fixed Modifications" help="You can specify a modification when present in a motif. For instance, 0.998@N!{P}[ST] is a deamidation modification on N only if it is present in an N[any but P][S or T] motif (N-glycosite).">
+            <param name="custom_mod" type="text">
+            </param>
+        </repeat>
+
+        <param name="acetyl_protein_nterm" type="boolean" label="Allow N-terminal protein acetylation as a variable modification" truevalue="-y" falsevalue="" />        
+        
+
+        <param name="missed_cleavages" type="select" format="text" help="Allow peptides to contain up to this many missed enzyme cleavage sites">
+            <label>Missed Cleavages Allowed</label>
+            <option value="0">0</option>        
+            <option value="1">1</option>
+            <option selected="true" value="2">2</option>
+        </param>
+
+        <param name="cleavage_semi" type="boolean" label="Allow semi-cleaved peptides" help="This can increase search time dramatically" truevalue="--cleavage-semi" falsevalue=""/>
+
+        <param name="keep_spectra" type="boolean" label="Keep Spectra" help="Include spectra in the output" truevalue="--output-spectra" falsevalue=""/>
+
+        <param name="threads" type="integer" value="1" label="Threads" help="Number of threads to use for search. Maximum is 16"/>
+        
+        <param name="enzyme" type="select" format="text">
+            <label>Enzyme</label>
+            <option value="[R]__pc__{P}">argc - [R]|{P}</option>
+            <option value="[X]__pc__[D]">aspn - [X]|[D]</option>
+            <option value="[FLMWY]__pc__{P}">chymotrypsin - [FLMWY]|{P}</option>
+            <option value="[R]__pc__[X]">clostripain - [R]|[X]</option>
+            <option value="[M]__pc__{X}">cnbr - [M]|{X}</option>
+            <option value="[AGILV]__pc__{P}">elastase - [AGILV]|{P}</option>
+            <option value="[D]__pc__{P}">formicacid - [D]|{P}</option>
+            <option value="[DE]__pc__{P}">gluc - [DE]|{P}</option>
+            <option value="[E]__pc__{P}">gluc_bicarb - [E]|{P}</option>
+            <option value="[W]__pc__[X]">iodosobenzoate - [W]|[X]</option>
+            <option value="[K]__pc__{P}">lysc - [K]|{P}</option>
+            <option value="[K]__pc__[X]">lysc-p - [K]|[X]</option>
+            <option value="[X]__pc__[K]">lysn - [X]|[K]</option>
+            <option value="[X]__pc__[AKRS]">lysn_promisc - [X]|[AKRS]</option>
+            <option value="[X]__pc__[X]">nonspecific - [X]|[X]</option>
+            <option value="[FL]__pc__[X]">pepsina - [FL]|[X]</option>
+            <option value="[P]__pc__[X]">protein_endopeptidase - [P]|[X]</option>
+            <option value="[E]__pc__[X]">staph_protease - [E]|[X]</option>
+            <option value="[FMWY]__pc__{P},[KR]__pc__{P},[X]__pc__[D]">tca - [FMWY]|{P},[KR]|{P},[X]|[D]</option>
+            <option value="[KR]__pc__{P}" selected="true">trypsin - [KR]|{P}</option>
+            <option value="[FKLMRWY]__pc__{P}">trypsin/chymotrypsin - [FKLMRWY]|{P}</option>
+            <option value="[KR]__pc__{P},[M]__pc__{P}">trypsin/cnbr - [KR]|{P},[M]|{P}</option>
+            <option value="[DEKR]__pc__{P}">trypsin_gluc - [DEKR]|{P}</option>
+        </param>
+
+        <param name="fragment_ion_tol" help="Fragment Ion Tolerance in Daltons" type="float" value="0.5" min="0" max="10000" label="Fragment ion tolerance"/>
+        <param name="precursor_ion_tol" help="Precursor Ion Tolerance (Da or ppm)" type="float" value="10" min="0" max="10000" label="Precursor ion tolerance"/>
+        <param name="precursor_tolu" type="select" format="text">
+            <label>Precursor Ion Tolerance Units</label>
+            <option value="ppm">ppm</option>
+            <option value="Da">Da</option>
+        </param>
+        <param name="allow_multi_isotope_search" type="boolean" label="Allow multi-isotope search" help="This allows peptide candidates in windows around -1 Da and -2 Da from the acquired mass to be considered. Only applicable when the minus/plus window above is set to less than 0.5 Da. Good for accurate-mass instruments for which the reported precursor mass is not corrected to the monoisotopic mass." truevalue="--multi-isotope-search" falsevalue=""/>
+    </inputs>
+    <outputs>
+        <data format="tandem" name="output" metadata_source="input_file" label="X!Tandem_vs_${database.dbkey if $database.has_key('dbkey') else $database.fasta_file.display_name}.${input_file.display_name}.${input_file.display_name}.tandem"/>
+    </outputs>
+    <tests>
+        <!-- Just test that the tool runs and produces vaguely correct output -->
+        <test>
+            <param name="source_select" value="input_ref"/>
+            <param name="fasta_file" value="testdb.fasta" format="fasta"/>
+            <param name="input_file" value="tiny.mzML" format="mzml"/>
+            <output name="output" format="tandem">
+                <assert_contents>
+                    <has_text text="tandem-style" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
   <help>
 
 **What it does**

--- a/xtandem/tandem.xml
+++ b/xtandem/tandem.xml
@@ -66,7 +66,6 @@
                 <param name="fasta_file" type="data" format="fasta" label="Uploaded FASTA file" />
             </when>
         </conditional>
-        
         <conditional name="tandem_params">
             <param name="source_select" type="select" label="Baseline Parameters">
                 <option value="built_in" selected="true">Built-In</option>
@@ -76,7 +75,7 @@
                 <param name="paramskey" type="select" format="text" >
                     <label>Paramset</label>
                     <option value="isb_kscore">ISB K-Score (Recommended for TPP)</option>
-                    <option value="isb_native">ISB Native</option>        
+                    <option value="isb_native">ISB Native</option>
                     <option value="gpm">GPM</option>
                 </param>
             </when>
@@ -99,8 +98,7 @@
             <param name="custom_mod" type="text">
             </param>
         </repeat>
-        
-        
+
         <param name="fixed_mods" format="text" type="select" multiple="true" label="Fixed Modifications" help="Hold the appropriate key while
             clicking to select multiple items">
             <options from_file="tandem_mods.loc">
@@ -115,17 +113,14 @@
         </repeat>
 
         <param name="acetyl_protein_nterm" type="boolean" label="Allow N-terminal protein acetylation as a variable modification" truevalue="-y" falsevalue="" />        
-        
-
         <param name="missed_cleavages" type="select" format="text" help="Allow peptides to contain up to this many missed enzyme cleavage sites">
             <label>Missed Cleavages Allowed</label>
-            <option value="0">0</option>        
+            <option value="0">0</option>
             <option value="1">1</option>
             <option selected="true" value="2">2</option>
         </param>
 
         <param name="cleavage_semi" type="boolean" label="Allow semi-cleaved peptides" help="This can increase search time dramatically" truevalue="--cleavage-semi" falsevalue=""/>
-
         <param name="keep_spectra" type="boolean" label="Keep Spectra" help="Include spectra in the output" truevalue="--output-spectra" falsevalue=""/>
 
         <param name="enzyme" type="select" format="text">

--- a/xtandem/tandem_to_pepxml.xml
+++ b/xtandem/tandem_to_pepxml.xml
@@ -1,12 +1,10 @@
 <tool id="tandem_to_pepxml_1" name="Tandem to pepXML" version="1.1.0">
+    <description>Converts a tandem result file to pepXML</description>
 	<requirements>
          <container type="docker">iracooke/protk-1.4.1</container>
 	    <requirement type="package" version="1.4">protk</requirement>
 	    <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
     </requirements>
-
-	<description>Converts a tandem result file to pepXML</description>
-
 	<command>
 		tandem_to_pepxml.rb $input_file -o $output 
 	</command>

--- a/xtandem/tandem_to_pepxml.xml
+++ b/xtandem/tandem_to_pepxml.xml
@@ -1,36 +1,33 @@
 <tool id="tandem_to_pepxml_1" name="Tandem to pepXML" version="1.1.0">
     <description>Converts a tandem result file to pepXML</description>
-	<requirements>
+    <requirements>
          <container type="docker">iracooke/protk-1.4.1</container>
-	    <requirement type="package" version="1.4">protk</requirement>
-	    <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
+        <requirement type="package" version="1.4">protk</requirement>
+        <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
     </requirements>
-	<command>
-		tandem_to_pepxml.rb $input_file -o $output 
-	</command>
+    <command>
+        tandem_to_pepxml.rb $input_file -o $output 
+    </command>
 
-	<inputs>
-		<param name="input_file" type="data" format="tandem" multiple="false" label="Input File" help="X!Tandem results file"/>
-	</inputs>
+    <inputs>
+        <param name="input_file" type="data" format="tandem" multiple="false" label="Input File" help="X!Tandem results file"/>
+    </inputs>
 
-	<outputs>
-		<data format="raw_pepxml" metadata_source="input_file" name="output" label="${input_file.display_name}.pepXML" />
-	</outputs>
-
-	<help>
-		Convert X!Tandem results to pepXML
-	</help>
-
-	<tests>
-		<!-- Just test that the tool runs and produces vaguely correct output -->
-		<test>
-		    <param name="input_file" value="tandem_to_pepxml_test.tandem" format="tandem"/>
-		    <output name="output" format="raw_pepxml">
-		        <assert_contents>
-					<has_text text="SQVFQLESTFDV" />
-		        </assert_contents>
-		    </output>
-		</test>
-	</tests>
-
+    <outputs>
+        <data format="raw_pepxml" metadata_source="input_file" name="output" label="${input_file.display_name}.pepXML" />
+    </outputs>
+    <tests>
+        <!-- Just test that the tool runs and produces vaguely correct output -->
+        <test>
+            <param name="input_file" value="tandem_to_pepxml_test.tandem" format="tandem"/>
+            <output name="output" format="raw_pepxml">
+                <assert_contents>
+                    <has_text text="SQVFQLESTFDV" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+        Convert X!Tandem results to pepXML
+    </help>
 </tool>

--- a/xtandem/tandem_to_pepxml.xml
+++ b/xtandem/tandem_to_pepxml.xml
@@ -1,8 +1,8 @@
 <tool id="tandem_to_pepxml_1" name="Tandem to pepXML" version="1.1.0">
     <description>Converts a tandem result file to pepXML</description>
     <requirements>
-         <container type="docker">iracooke/protk-1.4.1</container>
-        <requirement type="package" version="1.4">protk</requirement>
+        <container type="docker">iracooke/protk-1.4.1</container>
+        <requirement type="package" version="1.4.2">protk</requirement>
         <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
     </requirements>
     <command>

--- a/xtandem/tool_dependencies.xml
+++ b/xtandem/tool_dependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="protk" version="1.4.2">
+        <repository name="package_protk_1_4_2" owner="iuc"/>
+    </package>
+</tool_dependency>


### PR DESCRIPTION
Hi @iracooke,

sorry this branch started as small fixes to make `planemo lint` happy, but it ended up as a branch with miscellaneous fixes:
- lot of `planemo lint` fixes 
- remove `$threads` in favour of GALAXY_SLOTS
- include protk 1.4.2 as dependency (depends on https://github.com/iracooke/protk-galaxytools/pull/3)

ToDo:
- JAVA_VMEM should also be removed and not set by the user, this should be handled by `tool_conf.xml`
- you can get a DOI for your protk repository than we could use this to cite protk in all of these tools
- help needs to be improved
