### PR TITLE
spectrast with conda dependencies

### DIFF
--- a/spectrast/spectrast_create.xml
+++ b/spectrast/spectrast_create.xml
@@ -1,9 +1,11 @@
-<tool id="spectrast_create_1" name="SpectraST Create" version="1.0.0">
+<tool id="spectrast_create_1" name="SpectraST Create" version="5.0.0">
     <description>Create Spectral Libraries</description>
     <requirements>
+        <!--
         <container type="docker">iracooke/protk-1.4.3</container>
-        <requirement type="package" version="1.4.3">protk</requirement>
-        <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
+        -->
+        <requirement type="package" version="1.4.4a">protk</requirement>
+        <requirement type="package" version="5.0.0">tpp</requirement>
    </requirements>
     <stdio>
         <exit_code range="1:" level="fatal" description="Job Failed" />

--- a/spectrast/spectrast_filter.xml
+++ b/spectrast/spectrast_filter.xml
@@ -1,9 +1,11 @@
-<tool id="spectrast_filter_1" name="SpectraST Filter" version="1.0.0">
+<tool id="spectrast_filter_1" name="SpectraST Filter" version="5.0.0">
     <description>Filter and Manipulate Spectral Libraries</description>
     <requirements>
+        <!--
         <container type="docker">iracooke/protk-1.4.3</container>
-        <requirement type="package" version="1.4.3">protk</requirement>
-        <requirement type="package" version="4.8.0">trans_proteomic_pipeline</requirement>
+        -->
+        <requirement type="package" version="1.4.4a">protk</requirement>
+        <requirement type="package" version="5.0.0">tpp</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" level="fatal" description="Job Failed" />

--- a/spectrast/tool_dependencies.xml
+++ b/spectrast/tool_dependencies.xml
@@ -1,8 +1,0 @@
-<tool_dependency>
-    <package name="protk" version="1.4.3">
-        <repository name="package_protk_1_4_3" owner="iracooke"/>
-    </package>
-    <package name="trans_proteomic_pipeline" version="4.8.0">
-        <repository name="package_tpp_4_8_0" owner="iuc"/>
-    </package>
-</tool_dependency>


### PR DESCRIPTION
Commented out the container in the requirements, since this now references TPP v5.0.0.
Should the container be left in?  Or updated to a newer version?